### PR TITLE
Conditional Featured Image Output

### DIFF
--- a/wp-content/themes/humanity-theme/single.php
+++ b/wp-content/themes/humanity-theme/single.php
@@ -22,7 +22,7 @@ $article_has_sidebar = empty( $max_post_content ) ? 'has-sidebar' : '';
 
 <main id="main">
 	<?php
-	if ( !amnesty_post_has_header() ) {
+	if ( ! amnesty_post_has_header() ) {
 		get_template_part( 'partials/single/featured-image' );
 	}
 	?>

--- a/wp-content/themes/humanity-theme/single.php
+++ b/wp-content/themes/humanity-theme/single.php
@@ -21,7 +21,11 @@ $article_has_sidebar = empty( $max_post_content ) ? 'has-sidebar' : '';
 ?>
 
 <main id="main">
-	<?php get_template_part( 'partials/single/featured-image' ); ?>
+	<?php
+	if ( !amnesty_post_has_header() ) {
+		get_template_part( 'partials/single/featured-image' );
+	}
+	?>
 	<div class="section container article-container">
 		<section class="article <?php echo esc_attr( $article_has_sidebar ); ?>">
 			<header class="article-header">


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2853

If a post has a header block, do not output the featured image

**Steps to test**:
1.  Create a post
2. Add a featured image and a header block
3. Populate the header block with content
4. Save and view the front end
5. Only the header should be displayed

Example: http://bigbite.im/v/wFJAfE
