### PR TITLE
Stop slider extending outside header and footer

### DIFF
--- a/private/src/styles/blocks/slider/_main.scss
+++ b/private/src/styles/blocks/slider/_main.scss
@@ -221,6 +221,9 @@
 
 .slider {
   position: relative;
+  max-width: 1468px;
+  margin: 0 auto;
+  width: 100%;
 
   .flickity-enabled {
     display: flex;


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/8

Adds a max-width to the slider block to make sure it is contained within the header and footer

**Steps to test**:
1. Add slider block to /latest (Posts Page)
2. Save and view on the front end
3. The slider should NOT extend past the nav bar or footer

Example: http://bigbite.im/i/jgmB3t
