### PR TITLE
Add fallback path to search permalink helper

### DIFF
--- a/wp-content/themes/humanity-theme/includes/features/search/permalink.php
+++ b/wp-content/themes/humanity-theme/includes/features/search/permalink.php
@@ -72,13 +72,13 @@ if ( ! function_exists( 'amnesty_maybe_override_search_uri' ) ) {
 	 *
 	 * @package Amnesty
 	 *
-	 * @param string $url  the generated URI
-	 * @param string $path the requested path
+	 * @param string      $url  the generated URI
+	 * @param string|null $path the requested path
 	 *
 	 * @return string
 	 */
-	function amnesty_maybe_override_search_uri( string $url, string $path ): string {
-		if ( ! str_starts_with( $path, '/search/' ) ) {
+	function amnesty_maybe_override_search_uri( string $url, ?string $path = '/' ): string {
+		if ( ! str_starts_with( strval( $path ), '/search/' ) ) {
 			return $url;
 		}
 


### PR DESCRIPTION
Recreated from https://github.com/amnestywebsite/amnesty-wp-theme/pull/2811/

Steps to test:
1. go to `your-domain.tld?s=foo`
2. you should be redirected to `your-domain.tld/search/foo/` without issue