### PR TITLE
Skip download block setup if no elements found

### DIFF
--- a/private/src/scripts/modules/download-block.js
+++ b/private/src/scripts/modules/download-block.js
@@ -2,6 +2,10 @@ const setupFormControl = (block) => {
   const choices = block.querySelector('.checkboxGroup');
   const download = block.querySelector('.btn--download');
 
+  if (!choices || !download) {
+    return;
+  }
+
   choices.addEventListener('change', (event) => {
     const { target } = event;
     const {


### PR DESCRIPTION
Props: @gentyspun

Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2785
Recreated from: https://github.com/amnestywebsite/amnesty-wp-theme/pull/2849

Adds a conditional to stop the download block breaking the JS bundle

**Steps to test**:
1. Add download block to a post
2. Populate with multiple documents
3. Save and view front end
4. Open dev tools and check no warnings or errors appear relating to the download block

**Considerations**:
- Testing this requires some specific steps surrounding global media items and media items not included in different language sites.
