### PR TITLE
Remove unnecessary margin on LWI items

### DIFF
--- a/private/src/styles/blocks/links-with-icons/_group.scss
+++ b/private/src/styles/blocks/links-with-icons/_group.scss
@@ -51,10 +51,6 @@
 .linksWithIcons-group.is-horizontal .linksWithIcons {
   @include mq(medium-sm) {
     flex-basis: 33%;
-
-    &:nth-child(5) {
-      margin-top: 0;
-    }
   }
 }
 
@@ -81,10 +77,6 @@
 
   @include mq(medium-sm) {
     flex-basis: 24%;
-
-    &:nth-child(7) {
-      margin-top: 0;
-    }
   }
 }
 


### PR DESCRIPTION
Props: @gentyspun

Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2786
Recreated from: https://github.com/amnestywebsite/amnesty-wp-theme/pull/2841

Removes unnecessary styles that set margin top to zero on 5th and 7th links with icons, causing certain LIW items to sit out of line with the rest

**Steps to test**:
1.  Create a post
2. Add the Links with Icons block
3. Add at least 3 items and populate them with content
4. Save and view the front end
5. All items should sit in line with each other vertically

Example:
http://bigbite.im/i/IqlgiG
