### PR TITLE
Fix render of link list in custom input mode

### DIFF
--- a/private/src/scripts/editor/blocks/post-list/components/DisplayCustom.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/DisplayCustom.jsx
@@ -15,6 +15,8 @@ class DisplayCustom extends Component {
     tagLink: '',
     title: '',
     titleLink: '',
+    date: null,
+    authorName: '',
   };
 
   // eslint-disable-next-line camelcase
@@ -102,57 +104,74 @@ class DisplayCustom extends Component {
     let { custom = [] } = this.props;
     const { style, prefix } = this.props;
 
-    if (!custom.length > 0) {
+    if (style === 'petition') {
+      return null;
+    }
+
+    if (!custom.length) {
       custom = [{ ...DisplayCustom.defaultObject }];
     }
 
-    return (
-      <div>
-        {style !== 'grid' && (
+    let appender = null;
+    if (custom.length < 8) {
+      appender = (
+        <button onClick={this.addItem} className="add-more-button">
+          <BlockIcon icon="plus-alt" />
+          <span>{/* translators: [admin] */ __('Add another item', 'amnesty')}</span>
+        </button>
+      );
+    }
+
+    if (style !== 'grid') {
+      return (
+        <div>
           <ul className="linkList">
             {custom.map((item, index) => (
               <LinkList
                 key={`${prefix}-${index}`}
                 {...item}
+                showAuthor={this.props.showAuthor}
+                showPostDate={this.props.showPostDate}
                 createUpdate={this.createUpdateAttribute(index)}
                 createRemove={this.createRemoveItem(index)}
               />
             ))}
           </ul>
-        )}
+          {appender}
+        </div>
+      );
+    }
 
-        {style === 'grid' && [1, 2, 3, 5, 6, 7].indexOf(custom.length) > -1 ? (
-          <div className={`grid grid-${custom.length}`}>
-            {custom.map((item, index) => (
-              <GridItem
-                key={`${prefix}-${index}`}
-                {...item}
-                createUpdate={this.createUpdateAttribute(index)}
-                createRemove={this.createRemoveItem(index)}
-                updateMedia={this.createUpdateMediaAttribute(index)}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className={`grid grid-many`}>
-            {custom.map((item, index) => (
-              <GridItem
-                key={`${prefix}-${index}`}
-                {...item}
-                createUpdate={this.createUpdateAttribute(index)}
-                createRemove={this.createRemoveItem(index)}
-                updateMedia={this.createUpdateMediaAttribute(index)}
-              />
-            ))}
-          </div>
-        )}
+    // style === 'grid'
+    if ([1, 2, 3, 5, 6, 7].indexOf(custom.length) > -1) {
+      return (
+        <div className={`grid grid-${custom.length}`}>
+          {custom.map((item, index) => (
+            <GridItem
+              key={`${prefix}-${index}`}
+              {...item}
+              createUpdate={this.createUpdateAttribute(index)}
+              createRemove={this.createRemoveItem(index)}
+              updateMedia={this.createUpdateMediaAttribute(index)}
+            />
+          ))}
+          {appender}
+        </div>
+      );
+    }
 
-        {custom.length < 8 && (
-          <button onClick={this.addItem} className="add-more-button">
-            <BlockIcon icon="plus-alt" />
-            <span>{/* translators: [admin] */ __('Add another item', 'amnesty')}</span>
-          </button>
-        )}
+    return (
+      <div className={`grid grid-many`}>
+        {custom.map((item, index) => (
+          <GridItem
+            key={`${prefix}-${index}`}
+            {...item}
+            createUpdate={this.createUpdateAttribute(index)}
+            createRemove={this.createRemoveItem(index)}
+            updateMedia={this.createUpdateMediaAttribute(index)}
+          />
+        ))}
+        {appender}
       </div>
     );
   }

--- a/private/src/scripts/editor/blocks/post-list/components/display/LinkList.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/display/LinkList.jsx
@@ -11,16 +11,16 @@ const LinkItem = (props) => (
       </h3>
       <div className="postInfo-container">
         {props.showPostDate && (
-          <span className="linkList-itemDate">
-            <p className="dateTerm">Date: </p>
-            <p className="dateDescription"> {props.date} </p>
-          </span>
+          <p className="linkList-itemDate">
+            <span className="dateTerm">Date: </span>
+            <span className="dateDescription">{props.date}</span>
+          </p>
         )}
         {props.showAuthor && (
-          <span className="linkList-itemAuthor">
-            <p className="authorTerm"> Author: </p>
-            <p className="authorDescription"> {props.authorName} </p>
-          </span>
+          <p className="linkList-itemAuthor">
+            <span className="authorTerm">Author: </span>
+            <span className="authorDescription">{props.authorName}</span>
+          </p>
         )}
       </div>
     </article>

--- a/private/src/scripts/editor/blocks/post-list/components/editable/LinkList.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/editable/LinkList.jsx
@@ -1,41 +1,110 @@
 const { RichText, URLInputButton } = wp.blockEditor;
-const { IconButton } = wp.components;
+const { Button, DatePicker } = wp.components;
+const { useState } = wp.element;
 const { __ } = wp.i18n;
 
-const LinkItem = (props) => (
-  <li>
-    <article className="linkList-item">
-      <span className="linkList-itemMeta">
-        <RichText
-          tagName="a"
-          onChange={props.createUpdate('tagText')}
-          value={props.tagText}
-          // translators: [admin]
-          placeholder={__('(Tag Name)', 'amnesty')}
-          keepPlaceholderOnFocus={true}
-          allowedFormats={[]}
-          format="string"
-        />
-        <URLInputButton url={props.tagLink} onChange={props.createUpdate('tagLink')} />
-      </span>
-      <h3 className="linkList-itemTitle">
-        <RichText
-          tagName="a"
-          onChange={props.createUpdate('title')}
-          value={props.title}
-          // translators: [admin]
-          placeholder={__('(Insert Title)', 'amnesty')}
-          keepPlaceholderOnFocus={true}
-          allowedFormats={[]}
-          format="string"
-        />
-        <URLInputButton url={props.titleLink} onChange={props.createUpdate('titleLink')} />
-      </h3>
-      <div className="linkList-options">
-        <IconButton onClick={props.createRemove} icon="trash" />
-      </div>
-    </article>
-  </li>
-);
+const LinkItem = (props) => {
+  const [datePickerIsVisible, showDatePicker] = useState(false);
+  const setDate = props.createUpdate('date');
+
+  const chooseDate = (value) => {
+    setDate(value);
+    showDatePicker(false);
+  };
+
+  return (
+    <li>
+      <article className="linkList-item">
+        <span className="linkList-itemMeta">
+          <RichText
+            tagName="a"
+            onChange={props.createUpdate('tagText')}
+            value={props.tagText}
+            // translators: [admin]
+            placeholder={__('Tag Name', 'amnesty')}
+            keepPlaceholderOnFocus={true}
+            allowedFormats={[]}
+            format="string"
+          />
+          <URLInputButton
+            url={props.tagLink}
+            onChange={props.createUpdate('tagLink')}
+            isPressed={false}
+          />
+        </span>
+        <h3 className="linkList-itemTitle">
+          <RichText
+            tagName="a"
+            onChange={props.createUpdate('title')}
+            value={props.title}
+            // translators: [admin]
+            placeholder={__('Insert Title', 'amnesty')}
+            keepPlaceholderOnFocus={true}
+            allowedFormats={[]}
+            format="string"
+          />
+          <URLInputButton
+            url={props.titleLink}
+            onChange={props.createUpdate('titleLink')}
+            isPressed={false}
+          />
+        </h3>
+
+        <div className="postInfo-container">
+          {props.showPostDate && (
+            <div className="linkList-itemDate">
+              {/* translators: [admin/front] */}
+              <span className="dateTerm">{__('Date:', 'amnesty')}</span>
+              {props.date && <span className="dateDescription">
+                  {(new Date(props.date)).toLocaleDateString()}
+                </span>}
+              <Button
+                icon="calendar-alt"
+                isPressed={false}
+                onClick={() => showDatePicker(!datePickerIsVisible)}
+              />
+              <br />
+              {/* translators: [admin] */}
+              <small className="linkList-itemDateData">
+                <em>{__('Date may render differently on the site frontend', 'amnesty')}</em>
+              </small>
+              {datePickerIsVisible && (
+                <div className="linkList-datePicker">
+                  <DatePicker
+                    className="dateDescription"
+                    currentDate={props.date}
+                    onChange={chooseDate}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+          {props.showAuthor && (
+            <p className="linkList-itemAuthor">
+              {/* translators: [admin/front] */}
+              <span className="authorTerm">{__('Author:', 'amnesty')}</span>
+              <RichText
+                tagName="span"
+                className="authorDescription"
+                value={props.authorName}
+                onChange={props.createUpdate('authorName')}
+                multiline={false}
+                allowedFormats={[]}
+                format="string"
+                // translators: [admin]
+                placeholder={__('Author Name', 'amnesty')}
+                keepPlaceholderOnFocus={true}
+              />
+            </p>
+          )}
+        </div>
+
+        <div className="linkList-options">
+          <Button onClick={props.createRemove} icon="trash" />
+        </div>
+      </article>
+    </li>
+  );
+}
 
 export default LinkItem;

--- a/private/src/styles/blocks/linklist/_editor.scss
+++ b/private/src/styles/blocks/linklist/_editor.scss
@@ -1,7 +1,51 @@
-.linkList-itemAuthor::before {
-  content: " ";
-  height: 12px;
-  width: 1px;
-  background: $color-black;
-  margin: 10px;
+.linkList,
+.linkList * {
+  box-sizing: border-box;
+}
+
+.linkList-itemMeta,
+.linkList-itemTitle,
+.linkList-itemDate {
+  position: static;
+  gap: 6px;
+}
+
+.linkList-itemMeta {
+  display: inline-flex;
+}
+
+.linkList-itemTitle {
+  display: flex;
+}
+
+.linkList-itemTitle > a::after {
+  display: none;
+}
+
+.linkList-itemMeta .components-button,
+.linkList-itemTitle .components-button,
+.linkList-itemDate .components-button {
+  background: $color-white;
+}
+
+.linkList-itemDate {
+  position: relative;
+  flex-wrap: wrap;
+}
+
+.linkList-itemDate .dateTerm {
+  padding: 0;
+}
+
+.linkList-itemDateData {
+  display: block;
+  width: 100%;
+}
+
+.linkList-datePicker {
+  position: absolute;
+  z-index: 100;
+  border: 1px solid #949292;
+  padding: 6px;
+  background: $color-white;
 }

--- a/private/src/styles/blocks/linklist/_main.scss
+++ b/private/src/styles/blocks/linklist/_main.scss
@@ -1,6 +1,7 @@
 .linkList {
   list-style: none;
   margin-left: 0;
+  padding: 0;
 }
 
 .linkList li {
@@ -66,7 +67,7 @@
 
 .postInfo-container {
   display: flex;
-  flex-direction: column;
+  align-items: center;
 }
 
 .linkList-itemDate {
@@ -93,7 +94,7 @@
 
 .linkList-itemAuthor {
   display: flex;
-  align-items: baseline;
+  margin-bottom: 0;
 }
 
 .linkList-authorDivider {

--- a/wp-content/themes/humanity-theme/includes/blocks/post-list/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/post-list/render.php
@@ -210,27 +210,45 @@ if ( ! function_exists( 'amnesty_list_process_custom' ) ) {
 			return false;
 		}
 
+		$show_author = $attributes['displayAuthor'] ?? false;
+		$show_date   = $attributes['displayPostDate'] ?? false;
+
 		return array_map(
-			// phpcs:ignore Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum
-			function ( $data ) {
-				$featured_image = '';
-
-				if ( isset( $data['featured_image_id'] ) && $data['featured_image_id'] ) {
-						$featured_image = wp_get_attachment_image_url( $data['featured_image_id'], 'post-half@2x' );
-				}
-
-				return [
-					'title'             => isset( $data['title'] ) ? $data['title'] : false,
-					'link'              => isset( $data['titleLink'] ) ? $data['titleLink'] : false,
-					'tag'               => isset( $data['tagText'] ) ? $data['tagText'] : false,
-					'tag_link'          => isset( $data['tagLink'] ) ? $data['tagLink'] : false,
-					'featured_image'    => $featured_image,
-					'featured_image_id' => $data['featured_image_id'] ?? 0,
-					'excerpt'           => isset( $data['excerpt'] ) ? $data['excerpt'] : false,
-				];
-			},
+			fn ( array $data ): array => amnesty_list_process_custom_item_data( $data, $show_author, $show_date ),
 			$attributes['custom']
 		);
+	}
+}
+
+if ( ! function_exists( 'amnesty_list_process_custom_item_data' ) ) {
+	/**
+	 * Process a custom item's attributes
+	 *
+	 * @package Amnesty\Blocks
+	 *
+	 * @param array<string,mixed> $data the item data
+	 * @param bool                $show_author whether to render author info
+	 * @param bool                $show_date   whether to render specified date
+	 *
+	 * @return array<string,mixed>
+	 */
+	function amnesty_list_process_custom_item_data( array $data, bool $show_author, bool $show_date ): array {
+		$image = wp_get_attachment_image_url( $data['featured_image_id'] ?? 0, 'post-half@2x' );
+		$date  = amnesty_locale_date( strtotime( $data['date'] ?? '' ) );
+
+		return [
+			'title'             => $data['title'] ?? false,
+			'link'              => $data['titleLink'] ?? false,
+			'tag'               => $data['tagText'] ?? false,
+			'tag_link'          => $data['tagLink'] ?? false,
+			'featured_image'    => $image,
+			'featured_image_id' => $data['featured_image_id'] ?? 0,
+			'excerpt'           => $data['excerpt'] ?? false,
+			'showPostDate'      => $show_date,
+			'date'              => $date,
+			'showAuthor'        => $show_author,
+			'author'            => $data['authorName'] ?? '',
+		];
 	}
 }
 

--- a/wp-content/themes/humanity-theme/includes/blocks/post-list/views/list-item-meta.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/post-list/views/list-item-meta.php
@@ -4,9 +4,13 @@ if ( ! isset( $data['tag'], $data['tag_link'] ) ) {
 	return;
 }
 
+if ( ! $data['tag'] ) {
+	return;
+}
+
 $output = esc_html( $data['tag'] );
 
-if ( isset( $data['tag_link'] ) && ! ! $data['tag_link'] ) {
+if ( $data['tag_link'] ) {
 	$output = sprintf( '<a href="%s" tabindex="0">%s</a>', esc_url( $data['tag_link'] ), esc_html( $data['tag'] ) );
 }
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2780
Recreated from: https://github.com/amnestywebsite/amnesty-wp-theme/pull/2792

Currently, when using the Post List block in `Link List` mode, both the list and grid mode display components are rendered.
Further, the content areas in the list mode component are hard to edit, as they are all collapsed on top of each other.

This PR fixes both issues.

**Steps to test**:
1. First, insert a Post List block into a post, and switch the Type to Custom
2. See that the current issue is as described above
3. Checkout this branch, and rebuild the assets
4. Hard reload the post
5. See that the rendering of the editable components is much improved
6. Switch to grid mode
7. The grid item should render correctly
8. Switch back to list mode
9. Add some items, and save the post
10. Preview the post
11. The preview should render correctly
