### PR TITLE
Revert paragraph changes from 48d9bb8

### DIFF
--- a/private/src/styles/base/_type.scss
+++ b/private/src/styles/base/_type.scss
@@ -20,21 +20,6 @@
 
 p {
   overflow-wrap: break-word;
-  max-width: 860px;
-}
-
-p.has-text-align-center {
-  margin-right: auto;
-  margin-left: auto;
-}
-
-p.has-text-align-right {
-  margin-left: auto;
-}
-
-.rtl p.has-text-align-right {
-  margin-right: auto;
-  margin-left: 0;
 }
 
 p.has-drop-cap:not(:focus)::first-letter {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/99

Removes paragraph width limitation.

**Steps to test**:
1. View a country page
2. Paragraphs should extend to the full width of their containers
3. View a News post
4. Paragraphs should extend to the full width of their containers
5. View the homepage
6. Paragraphs should extend to the full width of their containers

