### PR TITLE
iFrame Block Styles

### DIFF
--- a/private/src/scripts/editor/blocks/iframe-button/index.jsx
+++ b/private/src/scripts/editor/blocks/iframe-button/index.jsx
@@ -43,18 +43,13 @@ registerBlockType('amnesty-core/iframe-button', {
     {
       name: 'default',
       // translators: [admin]
-      label: __('Primary (Yellow)', 'amnesty'),
+      label: __('Primary', 'amnesty'),
       isDefault: true,
     },
     {
       name: 'dark',
       // translators: [admin]
       label: __('Dark', 'amnesty'),
-    },
-    {
-      name: 'light',
-      // translators: [admin]
-      label: __('Light', 'amnesty'),
     },
   ],
 

--- a/private/src/scripts/editor/blocks/utils.js
+++ b/private/src/scripts/editor/blocks/utils.js
@@ -160,6 +160,13 @@ export const randId = () =>
  * @returns {String}
  */
 export const httpsOnly = (string) => {
-  const url = new URL(string.replace(/^http:/, 'https:'));
+  let url;
+
+  try {
+    url = new URL(string.replace(/^http:/, 'https:'));
+  } catch (e) {
+    return '';
+  }
+
   return url.protocol === 'https:' ? url.toString() : '';
 };


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/14

Removes brand block styles and adds them into the branding plugin (PR link below)

In conjunction with: 

**Steps to test**:
1. Make sure you have the branding plugin enabled
2. Add 3 iframe buttons to a post/page
3. Give each a different block style (Primary, Dark, Light)
4. Check placeholder text is visible and readable
5. Check hover styles
6. Populate, save and view the front end, checking the above again
7. Delete the blocks
8. Disable the branding plugin and repeat the process for non branding block styles

Example: http://bigbite.im/v/YX0guo
