### PR TITLE
Allow language names to be overridden in site options

### DIFF
--- a/private/src/scripts/admin.js
+++ b/private/src/scripts/admin.js
@@ -2,3 +2,4 @@ import '../styles/admin.scss';
 import './admin/cmb-events';
 import './admin/cmb-term-type';
 import './admin/ordered-list-preview';
+import './admin/options-general';

--- a/private/src/scripts/admin/options-general.js
+++ b/private/src/scripts/admin/options-general.js
@@ -1,0 +1,12 @@
+const settingsGeneral = () => {
+  const wplang = document.getElementById('WPLANG')?.parentElement?.parentElement;
+  const language = document.getElementById('amnesty-language-name')?.parentElement?.parentElement;
+
+  if (!wplang || !language) {
+    return;
+  }
+
+  wplang.insertAdjacentElement('beforeBegin', language);
+};
+
+document.addEventListener('DOMContentLoaded', settingsGeneral);

--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -78,6 +78,7 @@ require_once realpath( __DIR__ . '/includes/admin/class-accessibility.php' );
 require_once realpath( __DIR__ . '/includes/admin/class-fonts.php' );
 require_once realpath( __DIR__ . '/includes/admin/class-permalink-settings.php' );
 require_once realpath( __DIR__ . '/includes/admin/user-options.php' );
+require_once realpath( __DIR__ . '/includes/admin/settings-general.php' );
 #endregion admin
 
 /**

--- a/wp-content/themes/humanity-theme/includes/admin/settings-general.php
+++ b/wp-content/themes/humanity-theme/includes/admin/settings-general.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types = 1 );
+
+if ( ! function_exists( 'amnesty_register_general_settings' ) ) {
+	/**
+	 * Register custom fields on general settings page
+	 *
+	 * @package Amnesty\Plugins\CMB2
+	 *
+	 * @return void
+	 */
+	function amnesty_register_general_settings() {
+		add_settings_field(
+			'amnesty_language_name',
+			/* translators: [admin] */
+			__( 'Language Display Name', 'amnesty' ),
+			'amnesty_render_setting_language_name',
+			'general'
+		);
+
+		register_setting( 'general', 'amnesty_language_name', 'sanitize_text_field' );
+	}
+}
+
+if ( ! function_exists( 'amnesty_render_setting_language_name' ) ) {
+	/**
+	 * Render the language name settings field
+	 *
+	 * @package Amnesty\Plugins\CMB2
+	 *
+	 * @return void
+	 */
+	function amnesty_render_setting_language_name() {
+		$value = get_option( 'amnesty_language_name' );
+		printf(
+			'<input id="amnesty-language-name" class="regular-text" name="amnesty_language_name" type="text" value="%1$s">',
+			esc_attr( $value )
+		);
+
+		printf(
+			'<p class="description">%s</p>',
+			/* translators: [admin] */
+			esc_html__( 'Override the site language display name on the site frontend', 'amnesty' )
+		);
+	}
+}
+
+add_action( 'admin_init', 'amnesty_register_general_settings' );

--- a/wp-content/themes/humanity-theme/includes/mlp/language-selector.php
+++ b/wp-content/themes/humanity-theme/includes/mlp/language-selector.php
@@ -50,8 +50,13 @@ if ( ! function_exists( 'amnesty_get_object_translations' ) ) {
 				}
 			}
 
+			$lang = get_site_language_name( $translation->remoteSiteId() );
+			if ( ! $lang ) {
+				$lang = strip_language_name_parentheticals( $language->name() );
+			}
+
 			$i18n_sites[] = (object) [
-				'lang'      => preg_replace( '/\s*?([(（]).*?([)）])\s*?/ui', '', $language->name() ),
+				'lang'      => $lang,
 				'code'      => $language->isoCode(),
 				'direction' => $language->isRtl() ? 'rtl' : 'ltr',
 				'name'      => get_blog_option( $translation->remoteSiteId(), 'blogname' ),
@@ -99,10 +104,9 @@ if ( ! function_exists( 'render_language_selector_dropdown' ) ) {
 			}
 		}
 
-		$language = get_site_language_code();
-		$others   = array_filter( $sites, fn ( object $site ): bool => $language !== $site->code );
-		$current  = array_filter( $sites, fn ( object $site ): bool => $language === $site->code );
-		$current  = array_values( $current );
+		$others  = array_filter( $sites, fn ( object $site ): bool => get_current_blog_id() !== $site->blog_id );
+		$current = array_filter( $sites, fn ( object $site ): bool => get_current_blog_id() === $site->blog_id );
+		$current = array_values( $current );
 
 		if ( ! count( $current ) ) {
 			return;
@@ -111,9 +115,10 @@ if ( ! function_exists( 'render_language_selector_dropdown' ) ) {
 		$wrapper_open  = sprintf( '<nav class="page-nav page-nav--left" aria-label="%s" aria-expanded="false"><ul class="site-selector">', /* translators: [front] */ esc_attr__( 'Available languages', 'amnesty' ) );
 		$wrapper_close = '</ul></nav><div class="site-separator"></div>';
 
+		$current_item_name = get_blog_option( $current[0]->blog_id, 'amnesty_language_name' ) ?: $current[0]->lang;
 		$current_item_open = sprintf(
 			'<li id="menu-item-%2$s-%3$s" class="menu-item menu-item-current menu-item-has-children menu-item-%2$s-%3$s" dir="%4$s"><span>%1$s</span>',
-			esc_html( ucwords( $current[0]->lang, 'UTF-8' ) ),
+			esc_html( ucwords( $current_item_name, 'UTF-8' ) ),
 			esc_attr( $current[0]->blog_id ),
 			esc_attr( $current[0]->item_id ),
 			esc_attr( $current[0]->direction ),
@@ -165,14 +170,16 @@ if ( ! function_exists( 'render_language_selector_dropdown_item' ) ) {
 			return '';
 		}
 
-		$found = array_filter( $sites, fn ( object $remote ): bool => $remote->code === $site->code );
+		$found = array_filter( $sites, fn ( object $remote ): bool => $remote->name === $site->name );
 		$found = array_values( $found );
 
 		// fallback to homepage if no translation
 		if ( ! count( $found ) ) {
+			$name = get_blog_option( $site->site_id, 'ammesty_language_name' ) ?: $site->lang;
+
 			return sprintf(
 				'<li id="menu-item-%3$s-%4$s" class="menu-item menu-item-%3$s-%4$s" dir="%5$s"><a href="%2$s">%1$s</a></li>',
-				esc_html( $site->lang ),
+				esc_html( $name ),
 				esc_url( $site->url ),
 				esc_attr( $site->site_id ),
 				esc_attr( $site->post_id ),
@@ -182,10 +189,11 @@ if ( ! function_exists( 'render_language_selector_dropdown_item' ) ) {
 
 		$item = $found[0];
 		$link = 'post' === $item->type ? get_blog_permalink( $item->blog_id, $item->item_id ) : get_blog_term_link( $item->blog_id, $item->item_id );
+		$name = get_blog_option( $item->blog_id, 'ammesty_language_name' ) ?: $item->lang;
 
 		return sprintf(
 			'<li id="menu-item-%3$s-%4$s" class="menu-item menu-item-%3$s-%4$s" dir="%5$s"><a href="%2$s">%1$s</a></li>',
-			esc_html( $item->lang ),
+			esc_html( $name ),
 			esc_url( $link ),
 			esc_attr( $item->blog_id ),
 			esc_attr( $item->item_id ),

--- a/wp-content/themes/humanity-theme/includes/mlp/language-selector.php
+++ b/wp-content/themes/humanity-theme/includes/mlp/language-selector.php
@@ -130,6 +130,10 @@ if ( ! function_exists( 'render_language_selector_dropdown' ) ) {
 		$other_items_close  = '</ul>';
 
 		foreach ( amnesty_get_sites() as $site ) {
+			if ( $site->current ) {
+				continue;
+			}
+
 			$other_items_inner .= render_language_selector_dropdown_item( $site, $others );
 		}
 
@@ -165,12 +169,7 @@ if ( ! function_exists( 'render_language_selector_dropdown_item' ) ) {
 	 * @return string
 	 */
 	function render_language_selector_dropdown_item( object $site, array $sites ): string {
-		// change this to site id
-		if ( get_current_blog_id() === $site->site_id ) {
-			return '';
-		}
-
-		$found = array_filter( $sites, fn ( object $remote ): bool => $remote->name === $site->name );
+		$found = array_filter( $sites, fn ( object $remote ): bool => $remote->blog_id === $site->site_id );
 		$found = array_values( $found );
 
 		// fallback to homepage if no translation

--- a/wp-content/themes/humanity-theme/includes/multisite/class-core-site-list.php
+++ b/wp-content/themes/humanity-theme/includes/multisite/class-core-site-list.php
@@ -57,7 +57,7 @@ class Core_Site_List {
 			switch_to_blog( $blog_id );
 
 			$sites[] = (object) [
-				'lang'      => $this->get_lang( $blog_id ),
+				'lang'      => get_site_language_name( $blog_id ),
 				'code'      => get_site_language_code( $blog_id ),
 				'direction' => $this->get_direction( $blog_id ),
 				'name'      => get_bloginfo( 'name' ),
@@ -114,25 +114,6 @@ class Core_Site_List {
 		add_blog_option( $blog_id, 'amnesty_text_direction', $direction );
 
 		return $direction;
-	}
-
-	/**
-	 * Retrieve language identifier for blog.
-	 *
-	 * @param int $blog_id the blog context
-	 *
-	 * @return string
-	 */
-	protected function get_lang( $blog_id = 0 ) {
-		$lang = $this->get_locale( $blog_id );
-		$lang = locale_get_display_name( $lang, $lang );
-
-		if ( false === apply_filters( 'amnesty_strip_locale_country', true ) ) {
-			return $lang;
-		}
-
-		// strip country identifier from language display name
-		return preg_replace( '/\s*?([(（]).*?([)）])\s*?/ui', '', $lang );
 	}
 
 }


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2833

Steps to test:
1. go to wp admin -> settings -> general
2. there should be a new field above "site language" labelled "language display name"
3. if it's instead at the bottom of the page, that's a bug
4. put anything in this field and save the settings
5. the field value should populate with the data you entered when you reload the page
6. view the frontend
7. the language selector should show the data you entered instead of the site language name
8. the link should still point to the home page
9. view donate
10. the language selector should show the data you entered instead of the site language name 
11. the link should still point to donate
12. view latest
13. the language selector should show the data you entered instead of the site language name 
14. the link should still point to donate
15. view a post that's translated into that language
16. the language selector should show the data you entered instead of the site language name 
17. the link should still point to donate
18. view a post that isn't translated into that language
19. the language selector should show the data you entered instead of the site language name 
20. the link should point to the home page