### PR TITLE
Remove width constraint from, and fix labelling of, site logo

### DIFF
--- a/private/src/styles/layout/header/shared/_logo.scss
+++ b/private/src/styles/layout/header/shared/_logo.scss
@@ -1,23 +1,31 @@
 .logo {
-  display: block;
+  display: flex;
+  align-items: center;
   height: 60px;
-  max-width: 180px;
 
   @include mq(small) {
     height: 72px;
   }
 }
 
-.logo:empty {
-  @include icon(5px, 82px, 107px, 72px);
-  pointer-events: unset;
+.logo:empty::after {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 180px;
+  height: 100%;
   background-color: $color-primary;
+  border-right: 1px solid $color-grey-light;
+  content: attr(aria-label);
+}
+
+.rtl .logo:empty::after {
+  border-right: none;
+  border-left: 1px solid $color-grey-light;
 }
 
 .logo-logoType,
 .logo-logoMark {
-  height: 100%;
   max-height: 100% !important;
 }
 

--- a/wp-content/themes/humanity-theme/includes/helpers/media.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/media.php
@@ -50,8 +50,8 @@ if ( ! function_exists( 'get_theme_image_sizes' ) ) {
 			'hero-lg'          => [ 2560, 710, true ],
 			'hero-md'          => [ 1468, 710, true ],
 			'hero-sm'          => [ 770, 710, true ],
-			'logotype'         => [ 180, 72, false ],
-			'logotype@2x'      => [ 360, 144, false ],
+			'logotype'         => [ 0, 72, false ],
+			'logotype@2x'      => [ 0, 144, false ],
 			'logomark'         => [ 60, 60, false ],
 			'logomark@2x'      => [ 120, 120, false ],
 			'lwi-block-sm'     => [ 200, 200, false ],
@@ -119,7 +119,7 @@ if ( ! function_exists( 'amnesty_custom_image_sizes' ) ) {
 				'wc-thumb'         => 'WC thumb',
 				'action-wide'      => 'Action Wide',
 				'action-wide@2x'   => 'Action Wide Retina',
-			] 
+			]
 		);
 	}
 }

--- a/wp-content/themes/humanity-theme/includes/theme-setup/navigation.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/navigation.php
@@ -25,8 +25,7 @@ if ( ! function_exists( 'amnesty_logo' ) ) {
 				false,
 				[
 					'class' => 'logo-logoType',
-					/* translators: [front] Accessibility text for logo */
-					'alt'   => __( 'Amnesty International Logotype', 'amnesty' ),
+					'alt'   => get_bloginfo( 'name' ),
 				]
 			);
 		}
@@ -38,8 +37,7 @@ if ( ! function_exists( 'amnesty_logo' ) ) {
 				false,
 				[
 					'class' => 'logo-logoMark',
-					/* translators: [front] Accessibility text for logo */
-					'alt'   => __( 'Amnesty International Logomark', 'amnesty' ),
+					'alt'   => get_bloginfo( 'name' ),
 				]
 			);
 		}
@@ -47,8 +45,7 @@ if ( ! function_exists( 'amnesty_logo' ) ) {
 		printf(
 			'<a class="logo" href="%s" aria-label="%s">%s</a>',
 			esc_url( $logo_link ),
-			/* translators: [front] Screen reader accessibility text for logo to give context when clicking  */
-			esc_attr__( 'Visit the Amnesty International home page', 'amnesty' ),
+			esc_attr( get_bloginfo( 'name' ) ),
 			$logotype . $logomark // phpcs:ignore
 		);
 	}


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/116

**Steps to test**:
1. before checking out this branch, upload a very wide logo via WP admin -> Theme Options -> Site Logotype (the sample image provided below can be used)
2. view the site frontend
3. you should see that the logo is squashed
4. check out this branch and build assets
5. reload the frontend
6. the logo should have the correct aspect ratio, and not be squished, but it shouldn't fit the available vertical space
7. upload the same image again in WP admin -> Theme Options -> Site Logotype
8. reload the frontend
9. the image should be in the correct aspect ratio, and not be squished. it should also fill the available vertical space, and not overlap any adjacent items
10. remove both the Site Logotype and Site Logomark in WP admin -> Theme Options
11. reload the frontend
12. the space the logo previously filled should be replaced with the site title
13. the border of this area should be on the right in RTL, and on the left in LTR

