### PR TITLE
Remove 'hidden' capability from locations

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/regions/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/regions/render.php
@@ -37,21 +37,6 @@ if ( ! function_exists( 'amnesty_render_regions_block' ) ) {
 			'title_li'           => false,
 			'show_option_none'   => false,
 			'use_desc_for_title' => false,
-			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
-			'exclude'            => get_terms(
-				[
-					'taxonomy'   => $args['taxonomy'],
-					'hide_empty' => false,
-					'fields'     => 'ids',
-					'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-						[
-							'key'     => 'hidden',
-							'value'   => 'on',
-							'compare' => '=',
-						],
-					],
-				]
-			),
 		];
 
 		if ( $args['regionsOnly'] ) {

--- a/wp-content/themes/humanity-theme/includes/blocks/term-list/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/term-list/render.php
@@ -32,10 +32,6 @@ if ( ! function_exists( 'amnesty_term_list_block_get_terms' ) ) {
 							'compare' => 'NOT EXISTS',
 						],
 					],
-					[
-						'key'     => 'hidden',
-						'compare' => 'NOT EXISTS',
-					],
 				],
 			]
 		);

--- a/wp-content/themes/humanity-theme/includes/helpers/taxonomies.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/taxonomies.php
@@ -422,22 +422,6 @@ if ( ! function_exists( 'amnesty_get_locations_by_type' ) ) {
 			];
 		}
 
-		// exclude "hidden" terms from results
-		if ( false === $args['show_hidden'] ) {
-			$args['get_terms']['meta_query'][] = [
-				'relation' => 'OR',
-				[
-					'key'     => 'hidden',
-					'compare' => 'NOT EXISTS',
-				],
-				[
-					'key'     => 'hidden',
-					'value'   => 'on',
-					'compare' => '!=',
-				],
-			];
-		}
-
 		// ensure type is set correctly
 		if ( ! in_array( $args['type'], [ 'default', 'region', 'subregion' ], true ) ) {
 			$args['type'] = 'default';
@@ -637,12 +621,6 @@ if ( ! function_exists( 'get_terms_from_query_var' ) ) {
 			'taxonomy' => $tax ?: $qvar,
 		];
 
-		// prevent retrieval of hidden locations
-		if ( ( get_option( 'amnesty_location_slug' ) ?: 'location' ) === $args['taxonomy'] ) {
-			$args['meta_key']     = 'hidden';
-			$args['meta_compare'] = 'NOT EXISTS';
-		}
-
 		$term_list = get_terms( $args );
 
 		if ( is_wp_error( $term_list ) ) {
@@ -678,10 +656,6 @@ if ( ! function_exists( 'amnesty_find_locations' ) ) {
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query' => [
 				'relation' => 'AND',
-				[
-					'key'     => 'hidden',
-					'compare' => 'NOT EXISTS',
-				],
 				[
 					'key'     => 'type',
 					'value'   => [ 'region', 'subregion', 'default' ],
@@ -817,12 +791,6 @@ if ( ! function_exists( 'amnesty_taxonomy_to_option_list' ) ) {
 	function amnesty_taxonomy_to_option_list( WP_Taxonomy $taxonomy ): array {
 		$args = [ 'taxonomy' => $taxonomy->name ];
 		$opts = [];
-
-		// prevent retrieval of hidden locations
-		if ( ( get_option( 'amnesty_location_slug' ) ?: 'location' ) === $args['taxonomy'] ) {
-			$args['meta_key']     = 'hidden';
-			$args['meta_compare'] = 'NOT EXISTS';
-		}
 
 		$terms = get_terms( $args );
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2875

In conjunction with: https://github.com/amnestywebsite/wp-plugin-theme-companion/pull/45

**Steps to test**:
1. visit wp admin -> posts -> countries
2. edit a location term
3. the "Hide from blocks" checkbox should no longer be visible
4. edit a post
5. insert a terms list block
6. choose countries as the taxonomy
7. terms that were previously hidden should now be listed*

*To find terms in your db that were previously hidden:
```sql
select t.term_id, t.name from wp_termmeta as m
inner join wp_terms as t on m.term_id = t.term_id
where m.meta_key = 'hidden'
and m.meta_value = 'on'
order by t.name asc
```