### PR TITLE
Adjust sorting of terms in Term List block

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/term-list/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/term-list/render.php
@@ -75,31 +75,18 @@ if ( ! function_exists( 'amnesty_render_term_list_block' ) ) {
 			wp_cache_add( $cache_key, $terms );
 		}
 
-		$groups = [];
-
-		foreach ( $terms as $term ) {
-			$key = $term->name;
-			$key = remove_arabic_the( $key );
-			$key = mb_substr( $key, 0, 1, 'UTF-8' );
-			$key = mb_strtoupper( $key, 'UTF-8' );
-			$key = remove_accents( $key );
-			$key = remove_arabic_diacritics( $key );
-
-			if ( ! isset( $groups[ $key ] ) ) {
-				$groups[ $key ] = [];
-			}
-
-			$groups[ $key ][] = $term;
-		}
-
-		ksort( $groups );
+		$groups = group_terms_by_initial_ascii_letter( $terms );
 
 		foreach ( $groups as $key => &$terms ) {
-			usort( $terms, fn ( WP_Term $a, WP_Term $b ): int => $a->name <=> $b->name );
+			usort(
+				$terms,
+				fn ( WP_Term $a, WP_Term $b ): int =>
+					remove_accents( $a->name ) <=> remove_accents( $b->name )
+			);
 		}
 
 		$letters = array_keys( $groups );
-		$first   = $letters[0];
+		$first   = $letters[0]; // used in view
 
 		spaceless();
 		require realpath( __DIR__ . '/views/term-list.php' );

--- a/wp-content/themes/humanity-theme/includes/helpers/taxonomies.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/taxonomies.php
@@ -859,3 +859,35 @@ if ( ! function_exists( 'amnesty_filter_object_taxonomies_callback' ) ) {
 		return true;
 	}
 }
+
+if ( ! function_exists( 'group_terms_by_initial_ascii_letter' ) ) {
+	/**
+	 * Group an array of taxonomy terms by their first letters as ASCII
+	 *
+	 * @param array<int,WP_Term> $terms the terms to sort
+	 *
+	 * @return array<string,array<int,WP_Term>
+	 */
+	function group_terms_by_initial_ascii_letter( array $terms ): array {
+		$groups = [];
+
+		foreach ( $terms as $term ) {
+			$key = $term->name;
+			$key = remove_arabic_the( $key );
+			$key = mb_substr( $key, 0, 1, 'UTF-8' );
+			$key = mb_strtoupper( $key, 'UTF-8' );
+			$key = remove_accents( $key );
+			$key = remove_arabic_diacritics( $key );
+
+			if ( ! isset( $groups[ $key ] ) ) {
+				$groups[ $key ] = [];
+			}
+
+			$groups[ $key ][] = $term;
+		}
+
+		ksort( $groups );
+
+		return $groups;
+	}
+}


### PR DESCRIPTION
- Extract group sorting into helper function
- Sort terms as ASCII

Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2893

**Steps to test**:
1. visit countries landing page
2. look at the A-Z list of countries
3. in EN under the `C` group, Côte d'Ivoire should be listed between Congo and Croatia, rather than at the end of the list
4. in ES under the `B` group, Bélgica should appear between Bangladesh and Benín, rather than at the end of the list
5. in FR under the `B` group, Bélarus should appear between Bangladesh and Belgique, rather than at the end of the list
