### PR TITLE
Header Block - Fix Smaller/Normal size option 

### DIFF
--- a/private/src/styles/layout/_page-hero-editor.scss
+++ b/private/src/styles/layout/_page-hero-editor.scss
@@ -6,10 +6,11 @@
 .page-hero {
   padding-top: 111px;
   padding-bottom: 80px;
-  min-height: 710px;
+  min-height: 450px;
   background-size: cover;
   background-position: center center;
   color: $color-white;
+
 }
 
 .page-hero + .components-base-control {
@@ -72,6 +73,10 @@ p.page-heroContent {
 
 .page-heroSize--small {
   min-height: 450px;
+}
+
+.page-heroSize--large {
+  min-height: 710px;
 }
 
 .page-heroBackground--dark .page-heroContent,

--- a/private/src/styles/layout/_page-hero.scss
+++ b/private/src/styles/layout/_page-hero.scss
@@ -13,7 +13,7 @@
 
   @include mq(small) {
     padding-bottom: 80px;
-    min-height: 710px;
+    min-height: 450px;
     max-height: none;
     height: auto;
   }
@@ -94,6 +94,12 @@ p.page-heroContent {
 .page-heroSize--small {
   @include mq(small) {
     min-height: 450px;
+  }
+}
+
+.page-heroSize--large {
+  @include mq(small) {
+    min-height: 710px;
   }
 }
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2884

**Steps to test**:
1. Add a Header block to a post
2. Notice it is smaller than usual, and the "Normal" size option is selected
3. Save and view the front end, it should match the editor
4. Return to the editor and which between Normal and Large to notice the changes in size
5. Then Save for each and check they match on the front end as well

Example: http://bigbite.im/v/aoxZT1