### PR TITLE
A - Z block - make letter boxes larger

### DIFF
--- a/private/src/styles/blocks/term-list/_main.scss
+++ b/private/src/styles/blocks/term-list/_main.scss
@@ -15,11 +15,11 @@
   appearance: none;
   border: none;
   margin: 1px;
-  width: 60px;
-  height: 60px;
+  width: 75px;
+  height: 75px;
   background-color: $color-grey-x-light;
   font-family: var(--font-family-secondary);
-  font-size: 28px;
+  font-size: 30px;
   font-weight: bold;
   color: $color-black;
 

--- a/private/src/styles/blocks/term-list/_main.scss
+++ b/private/src/styles/blocks/term-list/_main.scss
@@ -19,7 +19,7 @@
   height: 75px;
   background-color: $color-grey-x-light;
   font-family: var(--font-family-secondary);
-  font-size: 30px;
+  font-size: 28px;
   font-weight: bold;
   color: $color-black;
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2897

**Steps to test**:
1. Navigate to /en/countries/
2. Z should no longer be on a row by itself in the A-Z

Example: http://bigbite.im/i/u9cIew
