### PR TITLE
Introduce gutters to article containers

### DIFF
--- a/private/src/styles/pages/article/_base.scss
+++ b/private/src/styles/pages/article/_base.scss
@@ -13,6 +13,7 @@
 .article-container {
   @include flexy-wrapper;
   margin-top: spacing();
+  padding: 0 40px;
 
   @include mq(large) {
     flex-wrap: nowrap;


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2595 Props @Gentyspun

**Steps to test**:
1. View a page or post
2. Check the left and right padding on the article container
3. It should be 40px each side
