### PR TITLE
Replace spaceless with plain output buffering in collapsible block

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/collapsable/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/collapsable/render.php
@@ -20,7 +20,7 @@ if ( ! function_exists( 'render_collapsable_block' ) ) {
 				'anchor'    => '',
 				'collapsed' => false,
 				'title'     => '',
-			] 
+			]
 		);
 
 		if ( ! $content ) {
@@ -33,8 +33,8 @@ if ( ! function_exists( 'render_collapsable_block' ) ) {
 			$wrapper_attrs['class'] = 'is-collapsed';
 		}
 
-		spaceless();
+		ob_start();
 		require realpath( __DIR__ . '/views/block.php' );
-		return endspaceless( false );
+		return ob_get_clean();
 	}
 }


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2918

**Steps to test**:
1. add a new post
2. insert a collapsable block
3. add some text, make some of it bold/add a link
4. there should be no missing whitespace after the bold/link text
