### PR TITLE
Register theme as translatable using Humanity Translation Management

### DIFF
--- a/wp-content/themes/humanity-theme/includes/theme-setup/text-domain.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/text-domain.php
@@ -57,3 +57,28 @@ if ( ! function_exists( 'amnesty_mofile_domain_prefix' ) ) {
 }
 
 add_filter( 'load_textdomain_mofile', 'amnesty_mofile_domain_prefix', 10, 2 );
+
+if ( ! function_exists( 'register_theme_as_translatable' ) ) {
+	/**
+	 * Register this theme as a translatable package
+	 *
+	 * @see https://github.com/amnestywebsite/humanity-translation-management
+	 *
+	 * @param array<int,array<string,string>> $packages existing packages
+	 *
+	 * @return array<int,array<string,string>>
+	 */
+	function register_theme_as_translatable( array $packages = [] ): array {
+		$packages[] = [
+			'id'     => 'humanity-theme',
+			'label'  => __( 'Humanity Theme', 'amnesty' ),
+			'path'   => get_template_directory(),
+			'pot'    => get_template_directory() . '/languages/amnesty.pot',
+			'domain' => 'amnesty',
+		];
+
+		return $packages;
+	}
+}
+
+add_filter( 'register_translatable_package', 'register_theme_as_translatable' );


### PR DESCRIPTION
**Steps to test**:
1. checkout branch
2. enable [Humanity Translation Management](https://github.com/amnestywebsite/humanity-translation-management) plugin
3. visit a non-EN site's wp admin
4. go to tools -> translations
5. there should be a tab for the Humanity Theme
6. the tab should list all available translations (see below screenshot)

![](http://bigbite.im/i/n5uycs+)