### PR TITLE
Bypass MLP relationship cache for requests via WP admin

### DIFF
--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -269,6 +269,7 @@ require_once realpath( __DIR__ . '/includes/mlp/helpers.php' );
 require_once realpath( __DIR__ . '/includes/mlp/language-selector.php' );
 if ( is_multilingualpress_enabled() ) {
 	require_once realpath( __DIR__ . '/includes/mlp/polyfills.php' );
+	require_once realpath( __DIR__ . '/includes/mlp/caching.php' );
 	require_once realpath( __DIR__ . '/includes/mlp/metadata.php' );
 	require_once realpath( __DIR__ . '/includes/mlp/rest-api.php' );
 	require_once realpath( __DIR__ . '/includes/mlp/scheduled-posts.php' );

--- a/wp-content/themes/humanity-theme/includes/mlp/caching.php
+++ b/wp-content/themes/humanity-theme/includes/mlp/caching.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types = 1 );
+
+use Inpsyde\MultilingualPress\Core\Admin\Settings\Cache\CacheSettingsOptions;
+
+if ( ! function_exists( 'disable_caching_multilingualpress_api_data' ) ) {
+	/**
+	 * Prevent caching of some MultilingualPress queries
+	 *
+	 * Only prevent this caching in requests via wp-admin,
+	 * so that frontend performance isn't impacted.
+	 * This is to work around an issue where translations
+	 * for posts are newly created, but the metabox doesn't
+	 * reflect the new relationship(s).
+	 *
+	 * @param mixed $value the option value
+	 *
+	 * @return mixed
+	 */
+	function disable_caching_multilingualpress_api_data( mixed $value ): mixed {
+		// settings defaults are in use - not retrieved from the database
+		if ( ! is_array( $value ) || ! isset( $value[ CacheSettingsOptions::OPTION_GROUP_API_NAME ] ) ) {
+			return $value;
+		}
+
+		// we don't want this impacting the frontend
+		if ( ! is_admin() && ! is_ajax() && ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) ) {
+			return $value;
+		}
+
+		// bypass caching of these data
+		$value[ CacheSettingsOptions::OPTION_GROUP_API_NAME ][ CacheSettingsOptions::OPTION_RELATIONS_API_NAME ] = false;
+
+		return $value;
+	}
+}
+
+add_filter( 'site_option_multilingualpress_internal_cache_setting', 'disable_caching_multilingualpress_api_data' );


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2573

**Steps to test**:
Can only really be tested on PRD, since the issue is not reproducible anywhere else.
To test that this PR raises no issues:
1. create/edit a post that currently has no translations
2. when there is content in the post:
3. scroll down to multilingualpress metabox
4. choose "create new post and use as translation in [lang]" for all sites
5. choose to copy content to new post
6. save the current post
7. the metabox should update correctly to show the new posts for each language
