### PR TITLE
Adds links with icons related patterns

### DIFF
--- a/private/src/scripts/editor/block-styles/group-block.js
+++ b/private/src/scripts/editor/block-styles/group-block.js
@@ -1,0 +1,8 @@
+const { registerBlockStyle } = wp.blocks;
+const { _x } = wp.i18n;
+
+registerBlockStyle('core/group', {
+  name: 'square-border',
+  // translators: [admin]
+  label: _x('Square Border', 'block style', 'amnesty'),
+});

--- a/private/src/scripts/editor/block-styles/index.js
+++ b/private/src/scripts/editor/block-styles/index.js
@@ -2,3 +2,4 @@ import './tabbed-content-block';
 import './social-links-block';
 import './table-block';
 import './button-block';
+import './group-block';

--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -85,6 +85,7 @@
 @import "blocks/core-blocks/social-links";
 @import "blocks/core-blocks/table";
 @import "blocks/core-blocks/video";
+@import "blocks/core-blocks/group";
 @import "blocks/countdown-timer/main";
 @import "blocks/custom-card/main";
 @import "blocks/download-block/style";

--- a/private/src/styles/blocks/core-blocks/_group.scss
+++ b/private/src/styles/blocks/core-blocks/_group.scss
@@ -1,0 +1,6 @@
+.wp-block-group.is-style-square-border {
+  border: 1px solid #000;
+  padding-top: 27px;
+  padding-bottom: 27px;
+  height: 100%;
+}

--- a/private/src/styles/gutenberg.scss
+++ b/private/src/styles/gutenberg.scss
@@ -62,6 +62,7 @@
 @import "blocks/core-blocks/rss-editor";
 @import "blocks/core-blocks/social-links";
 @import "blocks/core-blocks/social-links-editor";
+@import "blocks/core-blocks/group";
 @import "blocks/countdown-timer/editor";
 @import "blocks/custom-card/main";
 @import "blocks/custom-card/editor";

--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -143,7 +143,7 @@ require_once realpath( __DIR__ . '/includes/core-blocks/image/filters.php' );
  */
 #region patterns
 require_once realpath( __DIR__ . '/includes/block-patterns/pattern-category.php' );
-require_once realpath( __DIR__ . '/includes/block-patterns/pattern-category.php' );
+require_once realpath( __DIR__ . '/includes/block-patterns/social-share.php' );
 #endregion patterns
 
 /**

--- a/wp-content/themes/humanity-theme/functions.php
+++ b/wp-content/themes/humanity-theme/functions.php
@@ -143,7 +143,7 @@ require_once realpath( __DIR__ . '/includes/core-blocks/image/filters.php' );
  */
 #region patterns
 require_once realpath( __DIR__ . '/includes/block-patterns/pattern-category.php' );
-require_once realpath( __DIR__ . '/includes/block-patterns/social-share.php' );
+require_once realpath( __DIR__ . '/includes/block-patterns/pattern-category.php' );
 #endregion patterns
 
 /**

--- a/wp-content/themes/humanity-theme/includes/block-patterns/pattern-category.php
+++ b/wp-content/themes/humanity-theme/includes/block-patterns/pattern-category.php
@@ -11,16 +11,11 @@ if ( ! function_exists( 'amnesty_core_register_pattern_category' ) ) {
 	 * @return void
 	 */
 	function amnesty_core_register_pattern_category() {
-		// Block patterns were not introduced until WP v5.5.0
-		if ( ! function_exists( 'register_block_pattern_category' ) ) {
-			return;
-		}
-
 		register_block_pattern_category(
-			'amnesty-core',
+			'humanity',
 			[
 				/* translators: [admin] */
-				'label' => __( 'Amnesty Core', 'amnesty' ),
+				'label' => __( 'Humanity Theme', 'amnesty' ),
 			]
 		);
 	}

--- a/wp-content/themes/humanity-theme/patterns/33-33-33-links-with-icons-square.php
+++ b/wp-content/themes/humanity-theme/patterns/33-33-33-links-with-icons-square.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Title: 33/33/33 Links with Icons (square border)
+ * Description: A 33/33/33 layout with links and icons with a square border.
+ * Slug: amnesty/33-33-33-links-with-icons-square
+ * Keywords: 33/33/33, links, icons, square border
+ * Categories: humanity
+ */
+?>
+
+<!-- wp:amnesty-core/block-section -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"is-style-square-border","layout":{"type":"constrained"}} -->
+<div class="wp-block-group is-style-square-border"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"align":"center"} -->
+<figure class="wp-block-image aligncenter"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">(Insert Body Text)</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"is-style-square-border","layout":{"type":"constrained"}} -->
+<div class="wp-block-group is-style-square-border"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"align":"center"} -->
+<figure class="wp-block-image aligncenter"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">(Insert Body Text)</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:group {"className":"is-style-square-border","layout":{"type":"constrained"}} -->
+<div class="wp-block-group is-style-square-border"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"align":"center"} -->
+<figure class="wp-block-image aligncenter"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">(Insert Body Text)</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:amnesty-core/block-section -->

--- a/wp-content/themes/humanity-theme/patterns/33-33-33-links-with-icons.php
+++ b/wp-content/themes/humanity-theme/patterns/33-33-33-links-with-icons.php
@@ -11,69 +11,69 @@
 <!-- wp:amnesty-core/block-section -->
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
-    <div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
-    <h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
-    <!-- /wp:heading -->
+	<div class="wp-block-column"><!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
+	<h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+	<!-- /wp:heading -->
 
-    <!-- wp:image {"align":"center"} -->
-    <figure class="wp-block-image aligncenter"><img alt=""/></figure>
-    <!-- /wp:image -->
+	<!-- wp:image {"align":"center"} -->
+	<figure class="wp-block-image aligncenter"><img alt=""/></figure>
+	<!-- /wp:image -->
 
-    <!-- wp:paragraph {"align":"center"} -->
-    <p class="has-text-align-center">(Insert Body Text)</p>
-    <!-- /wp:paragraph -->
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center">(Insert Body Text)</p>
+	<!-- /wp:paragraph -->
 
-    <!-- wp:buttons -->
-    <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
-    <div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
-    <!-- /wp:button --></div>
-    <!-- /wp:buttons --></div>
-    <!-- /wp:group --></div>
-    <!-- /wp:column -->
+	<!-- wp:buttons -->
+	<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+	<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+	<!-- /wp:button --></div>
+	<!-- /wp:buttons --></div>
+	<!-- /wp:group --></div>
+	<!-- /wp:column -->
 
-    <!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
-    <div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
-    <h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
-    <!-- /wp:heading -->
+	<!-- wp:column -->
+	<div class="wp-block-column"><!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
+	<h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+	<!-- /wp:heading -->
 
-    <!-- wp:image {"align":"center"} -->
-    <figure class="wp-block-image aligncenter"><img alt=""/></figure>
-    <!-- /wp:image -->
+	<!-- wp:image {"align":"center"} -->
+	<figure class="wp-block-image aligncenter"><img alt=""/></figure>
+	<!-- /wp:image -->
 
-    <!-- wp:paragraph {"align":"center"} -->
-    <p class="has-text-align-center">(Insert Body Text)</p>
-    <!-- /wp:paragraph -->
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center">(Insert Body Text)</p>
+	<!-- /wp:paragraph -->
 
-    <!-- wp:buttons -->
-    <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
-    <div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
-    <!-- /wp:button --></div>
-    <!-- /wp:buttons --></div>
-    <!-- /wp:group --></div>
-    <!-- /wp:column -->
+	<!-- wp:buttons -->
+	<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+	<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+	<!-- /wp:button --></div>
+	<!-- /wp:buttons --></div>
+	<!-- /wp:group --></div>
+	<!-- /wp:column -->
 
-    <!-- wp:column -->
-    <div class="wp-block-column"><!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
-    <div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
-    <h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
-    <!-- /wp:heading -->
+	<!-- wp:column -->
+	<div class="wp-block-column"><!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
+	<h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+	<!-- /wp:heading -->
 
-    <!-- wp:image {"align":"center"} -->
-    <figure class="wp-block-image aligncenter"><img alt=""/></figure>
-    <!-- /wp:image -->
+	<!-- wp:image {"align":"center"} -->
+	<figure class="wp-block-image aligncenter"><img alt=""/></figure>
+	<!-- /wp:image -->
 
-    <!-- wp:paragraph {"align":"center"} -->
-    <p class="has-text-align-center">(Insert Body Text)</p>
-    <!-- /wp:paragraph -->
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center">(Insert Body Text)</p>
+	<!-- /wp:paragraph -->
 
-    <!-- wp:buttons -->
-    <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
-    <div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
-    <!-- /wp:button --></div>
-    <!-- /wp:buttons --></div>
-    <!-- /wp:group --></div>
-    <!-- /wp:column --></div>
-    <!-- /wp:columns -->
-    <!-- /wp:amnesty-core/block-section -->
+	<!-- wp:buttons -->
+	<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+	<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+	<!-- /wp:button --></div>
+	<!-- /wp:buttons --></div>
+	<!-- /wp:group --></div>
+	<!-- /wp:column --></div>
+	<!-- /wp:columns -->
+	<!-- /wp:amnesty-core/block-section -->

--- a/wp-content/themes/humanity-theme/patterns/33-33-33-links-with-icons.php
+++ b/wp-content/themes/humanity-theme/patterns/33-33-33-links-with-icons.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Title: 33-33-33 Links with Icons
+ * Description: Three columns with a heading, image, body text, and a button.
+ * Slug: amnesty/33-33-33-links-with-icons
+ * Keywords: links, icons
+ * Categories: humanity
+ */
+?>
+
+<!-- wp:amnesty-core/block-section -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+    <div class="wp-block-column"><!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
+    <div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
+    <h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:image {"align":"center"} -->
+    <figure class="wp-block-image aligncenter"><img alt=""/></figure>
+    <!-- /wp:image -->
+
+    <!-- wp:paragraph {"align":"center"} -->
+    <p class="has-text-align-center">(Insert Body Text)</p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:buttons -->
+    <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+    <div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+    <!-- /wp:button --></div>
+    <!-- /wp:buttons --></div>
+    <!-- /wp:group --></div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column"><!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
+    <div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
+    <h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:image {"align":"center"} -->
+    <figure class="wp-block-image aligncenter"><img alt=""/></figure>
+    <!-- /wp:image -->
+
+    <!-- wp:paragraph {"align":"center"} -->
+    <p class="has-text-align-center">(Insert Body Text)</p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:buttons -->
+    <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+    <div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+    <!-- /wp:button --></div>
+    <!-- /wp:buttons --></div>
+    <!-- /wp:group --></div>
+    <!-- /wp:column -->
+
+    <!-- wp:column -->
+    <div class="wp-block-column"><!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
+    <div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
+    <h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:image {"align":"center"} -->
+    <figure class="wp-block-image aligncenter"><img alt=""/></figure>
+    <!-- /wp:image -->
+
+    <!-- wp:paragraph {"align":"center"} -->
+    <p class="has-text-align-center">(Insert Body Text)</p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:buttons -->
+    <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+    <div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+    <!-- /wp:button --></div>
+    <!-- /wp:buttons --></div>
+    <!-- /wp:group --></div>
+    <!-- /wp:column --></div>
+    <!-- /wp:columns -->
+    <!-- /wp:amnesty-core/block-section -->

--- a/wp-content/themes/humanity-theme/patterns/links-with-icons-single-square.php
+++ b/wp-content/themes/humanity-theme/patterns/links-with-icons-single-square.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Links with Icons Single (square border)
+ * Description: Single column with a heading, image, body text, and a button. with a square border
+ * Slug: amnesty/links-with-icons-single-square
+ * Keywords: links, icons, square border
+ * Categories: humanity
+ */
+?>
+
+<!-- wp:group {"className":"is-style-square-border","layout":{"type":"constrained"}} -->
+<div class="wp-block-group is-style-square-border"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"align":"center"} -->
+<figure class="wp-block-image aligncenter"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">(Insert Body Text)</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->

--- a/wp-content/themes/humanity-theme/patterns/links-with-icons-single.php
+++ b/wp-content/themes/humanity-theme/patterns/links-with-icons-single.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Links with Icons Single
+ * Description: Single column with a heading, image, body text, and a button.
+ * Slug: amnesty/links-with-icons-single
+ * Keywords: links, icons
+ * Categories: humanity
+ */
+?>
+
+<!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
+<div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
+    <h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+    <!-- /wp:heading -->
+
+    <!-- wp:image {"align":"center"} -->
+    <figure class="wp-block-image aligncenter"><img alt=""/></figure>
+    <!-- /wp:image -->
+
+    <!-- wp:paragraph {"align":"center"} -->
+    <p class="has-text-align-center">(Insert Body Text)</p>
+    <!-- /wp:paragraph -->
+
+    <!-- wp:buttons -->
+    <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+    <div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+    <!-- /wp:button --></div>
+    <!-- /wp:buttons --></div>
+    <!-- /wp:group -->

--- a/wp-content/themes/humanity-theme/patterns/links-with-icons-single.php
+++ b/wp-content/themes/humanity-theme/patterns/links-with-icons-single.php
@@ -10,20 +10,20 @@
 
 <!-- wp:group {"className":"is-style-default","layout":{"type":"constrained"}} -->
 <div class="wp-block-group is-style-default"><!-- wp:heading {"textAlign":"center"} -->
-    <h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
-    <!-- /wp:heading -->
+	<h2 class="wp-block-heading has-text-align-center">(INSERT TITLE)</h2>
+	<!-- /wp:heading -->
 
-    <!-- wp:image {"align":"center"} -->
-    <figure class="wp-block-image aligncenter"><img alt=""/></figure>
-    <!-- /wp:image -->
+	<!-- wp:image {"align":"center"} -->
+	<figure class="wp-block-image aligncenter"><img alt=""/></figure>
+	<!-- /wp:image -->
 
-    <!-- wp:paragraph {"align":"center"} -->
-    <p class="has-text-align-center">(Insert Body Text)</p>
-    <!-- /wp:paragraph -->
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center">(Insert Body Text)</p>
+	<!-- /wp:paragraph -->
 
-    <!-- wp:buttons -->
-    <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
-    <div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
-    <!-- /wp:button --></div>
-    <!-- /wp:buttons --></div>
-    <!-- /wp:group -->
+	<!-- wp:buttons -->
+	<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+	<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button">(INSERT LINK TEXT)</a></div>
+	<!-- /wp:button --></div>
+	<!-- /wp:buttons --></div>
+	<!-- /wp:group -->


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/180 https://github.com/amnestywebsite/humanity-theme/issues/181

Adds 2 block patterns, one for a single Links With Icons that can be inserted into columns etc and another that is a pre-built 3 column Links With Icons pattern, also registers a block style for the group block to allow for the old square Links with Icons style

**Steps to test**:
1. Edit a post
2. Open the block inserter and check the new pattern appears under the patterns tab
3. Insert the pattern and check it matches the example in the ticket
4. Also check the new group block styles are present and function as expected (Add a square border around the group in the editor and the front end)

Example: http://bigbite.im/v/RR1cvJ