### PR TITLE
Chore/styling issues between brand plugin

### DIFF
--- a/private/src/styles/blocks/custom-card/_editor.scss
+++ b/private/src/styles/blocks/custom-card/_editor.scss
@@ -35,3 +35,8 @@
   color: $color-white;
   background-color: $color-black-x-dark;
 }
+
+.customCard-content .btn:hover {
+  background-color: $color-primary-state;
+  color: $color-primary;
+}

--- a/private/src/styles/blocks/custom-card/_main.scss
+++ b/private/src/styles/blocks/custom-card/_main.scss
@@ -94,3 +94,7 @@
   background-color: $color-black-x-dark;
   color: $color-white;
 }
+
+.is-style-style-3 .btn:hover {
+  background-color: $color-primary-state;
+}

--- a/private/src/styles/components/form/_checkbox-group.scss
+++ b/private/src/styles/components/form/_checkbox-group.scss
@@ -78,11 +78,15 @@
 
   &:hover,
   &:focus-within {
-    background: $color-primary;
+    background: $color-grey-light;
   }
 
   &:active {
     background: $color-primary-state;
+  }
+
+  &:active label {
+    color: $color-primary;
   }
 
   &:has(label[data-value=""]),
@@ -92,17 +96,21 @@
   }
 
   &:has(input:checked) {
-    background: $color-primary;
+    background: $color-primary-state;
   }
 
   &:has(input:checked):hover,
   &:has(input:checked):focus-within {
-    background: $color-primary-state;
+    background: $color-grey-mid-dark;
   }
 
   &:has(input:checked):focus,
   &:has(input:checked):active {
-    background: $color-primary;
+    background: $color-primary-state;
+  }
+
+  &:has(input:checked) label {
+    color: $color-primary;
   }
 }
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2871

Fixes form checkbox styles (Hover, Active etc) for Humanity colours on the front end, also fixes Humanity hover styles Custom Card block for editor and front end

**Steps to test**:
1. Deactivate the branding plugin
2. Navigate to /search
3. Open the "Year" filter and notice Humanity color hover and active styles
4. Edit a post and add the Custom Card block, test all style combinations in the editor and the front end, ensuring the button always has the relevant hover styles

Example: 
http://bigbite.im/i/0KJ9NC
http://bigbite.im/i/3XOsd6