### PR TITLE
Add gutters to most templates

### DIFF
--- a/private/src/styles/base/_container.scss
+++ b/private/src/styles/base/_container.scss
@@ -17,3 +17,7 @@
 .container--small {
   max-width: 1113px;
 }
+
+.has-gutter {
+  padding: 0 40px;
+}

--- a/private/src/styles/pages/_archive.scss
+++ b/private/src/styles/pages/_archive.scss
@@ -17,10 +17,6 @@
   }
 }
 
-.archive-slider {
-  margin-top: 24px;
-}
-
 .taxonomyArchive-filters {
   display: flex;
   flex-direction: column;

--- a/private/src/styles/pages/article/_base.scss
+++ b/private/src/styles/pages/article/_base.scss
@@ -19,10 +19,6 @@
   }
 }
 
-.article-container--report {
-  margin-top: 80px;
-}
-
 .article-container--report .article-content {
   padding-top: 30px;
   border-top: 1px solid $color-grey-sm-light;

--- a/private/src/styles/pages/article/_base.scss
+++ b/private/src/styles/pages/article/_base.scss
@@ -13,7 +13,6 @@
 .article-container {
   @include flexy-wrapper;
   margin-top: spacing();
-  padding: 0 40px;
 
   @include mq(large) {
     flex-wrap: nowrap;

--- a/wp-content/themes/humanity-theme/archive.php
+++ b/wp-content/themes/humanity-theme/archive.php
@@ -47,6 +47,11 @@ if ( is_a( $current_term, 'WP_Term' ) && 'category' === $current_term->taxonomy 
 		print '</div>';
 	}
 
+	?>
+	</div>
+	<div class="container has-gutter">
+	<?php
+
 	if ( '' != $term_name && '' != $term_description ) {
 		print '<div class="categoryTerm-title">';
 		printf( '<h1>%1$s</h1>', esc_html( $term_name ) );
@@ -62,9 +67,11 @@ if ( is_a( $current_term, 'WP_Term' ) && 'category' === $current_term->taxonomy 
 	}
 
 	?>
+	</div>
 
-		<section class="news-section section section--small section--dark section--topSpacing section--bottomSpacing" aria-label="<?php /* translators: [front] ARIA https://www.amnesty.eu/news/ a number followed by the string on the list of posts */ esc_attr_e( 'Results', 'amnesty' ); ?>">
-		<?php get_template_part( 'partials/archive/header' ); ?>
+	<div class="container has-gutter">
+		<section class="news-section section section--small section--dark" aria-label="<?php /* translators: [front] ARIA https://www.amnesty.eu/news/ a number followed by the string on the list of posts */ esc_attr_e( 'Results', 'amnesty' ); ?>">
+			<?php get_template_part( 'partials/archive/header' ); ?>
 			<div class="postlist">
 			<?php
 			while ( have_posts() ) {
@@ -76,7 +83,9 @@ if ( is_a( $current_term, 'WP_Term' ) && 'category' === $current_term->taxonomy 
 			?>
 			</div>
 		</section>
+	</div>
 
+	<div class="container has-gutter">
 	<?php get_template_part( 'partials/pagination' ); ?>
 	</div>
 </main>

--- a/wp-content/themes/humanity-theme/includes/helpers/frontend.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/frontend.php
@@ -96,3 +96,18 @@ if ( ! function_exists( 'amnesty_get_query_var' ) ) {
 		return get_query_var( $variable ) ?: ( $wp->query_vars[ $variable ] ?? '' );
 	}
 }
+
+if ( ! function_exists( 'amnesty_render_blocks' ) ) {
+	/**
+	 * Render an array of blocks
+	 *
+	 * @package Amnesty
+	 *
+	 * @param array<int,array<string,mixed>> $blocks the blocks to render
+	 *
+	 * @return string
+	 */
+	function amnesty_render_blocks( array $blocks ): string {
+		return implode( '', array_map( 'render_block', $blocks ) );
+	}
+}

--- a/wp-content/themes/humanity-theme/page-petitions.php
+++ b/wp-content/themes/humanity-theme/page-petitions.php
@@ -53,13 +53,19 @@ $opening_section = array_shift( $sections );
 
 ?>
 <main id="main">
-	<div class="container">
-		<?php $opening_section && print render_block( $opening_section ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		<section class="news-section section section--small section--topSpacing" aria-label="<?php /* translators: [front] */ esc_attr_e( 'All Petitions', 'amnesty' ); ?>">
+<?php if ( $opening_section ) : ?>
+	<section class="section">
+		<div class="container has-gutter">
+			<?php echo wp_kses_post( amnesty_render_blocks( $opening_section['innerBlocks'] ?? [] ) ); ?>
+		</div>
+	</section>
+<?php endif; ?>
 
-		<?php if ( ! empty( $heading_blocks[0] ) ) : ?>
-			<?php print render_block( $heading_blocks[0] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		<?php endif; ?>
+	<section class="section" aria-label="<?php /* translators: [front] */ esc_attr_e( 'All Petitions', 'amnesty' ); ?>">
+		<div class="container has-gutter">
+			<?php if ( isset( $heading_blocks[0] ) ) : ?>
+				<?php echo wp_kses_post( render_block( $heading_blocks[0] ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<?php endif; ?>
 
 			<div class="postlist">
 			<?php
@@ -74,8 +80,18 @@ $opening_section = array_shift( $sections );
 
 			?>
 			</div>
-		</section>
-		<?php count( $sections ) > 0 && array_map( fn ( $section ) => print render_block( $section ), $sections ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-	</div>
+		</div>
+	</section>
+	<?php
+
+	foreach ( $sections as $section ) {
+		echo '<section class="section">';
+		echo '<div class="container has-gutter">';
+		echo amnesty_render_blocks( $section['innerBlocks'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo '</div>';
+		echo '</section>';
+	}
+
+	?>
 </main>
 <?php get_footer(); ?>

--- a/wp-content/themes/humanity-theme/page.php
+++ b/wp-content/themes/humanity-theme/page.php
@@ -18,7 +18,7 @@ $sidebar_is_enabled    = amnesty_get_meta_field( '_disable_sidebar' ) !== '1';
 
 <main id="main">
 	<section class="section section--small">
-		<div class="container article-container">
+		<div class="container article-container has-gutter">
 			<article class="article <?php $sidebar_is_enabled && print 'has-sidebar'; ?>">
 			<?php if ( ! $hero_title ) : ?>
 				<header class="article-header">

--- a/wp-content/themes/humanity-theme/search.php
+++ b/wp-content/themes/humanity-theme/search.php
@@ -10,7 +10,7 @@ get_header();
 
 ?>
 <main id="main">
-	<div class="container search-container">
+	<div class="container search-container has-gutter">
 		<?php get_template_part( 'partials/search/horizontal-search' ); ?>
 
 		<section class="section search-results section--tinted" aria-label="<?php /* translators: [front] ARIA */ esc_attr_e( 'Search results', 'amnesty' ); ?>">
@@ -31,7 +31,7 @@ get_header();
 		</section>
 	</div>
 
-	<div class="container container--small">
+	<div class="container container--small has-gutter">
 		<?php get_template_part( 'partials/pagination' ); ?>
 	</div>
 

--- a/wp-content/themes/humanity-theme/searchpage.php
+++ b/wp-content/themes/humanity-theme/searchpage.php
@@ -24,7 +24,7 @@ if ( absint( get_query_var( 'paged' ) ) < 2 ) {
 
 ?>
 <main id="main">
-	<div class="container search-container">
+	<div class="container search-container has-gutter">
 		<?php get_template_part( 'partials/search/horizontal-search' ); ?>
 
 		<section class="section search-results section--tinted" aria-label="<?php /* translators: [front] ARIA */ esc_attr_e( 'Search results', 'amnesty' ); ?>">
@@ -50,7 +50,7 @@ if ( absint( get_query_var( 'paged' ) ) < 2 ) {
 		</section>
 	</div>
 
-	<div class="container">
+	<div class="container has-gutter">
 		<?php require locate_template( 'partials/search/pagination.php' ); ?>
 	</div>
 

--- a/wp-content/themes/humanity-theme/single.php
+++ b/wp-content/themes/humanity-theme/single.php
@@ -26,27 +26,30 @@ $article_has_sidebar = empty( $max_post_content ) ? 'has-sidebar' : '';
 		get_template_part( 'partials/single/featured-image' );
 	}
 	?>
-	<div class="section container article-container">
-		<section class="article <?php echo esc_attr( $article_has_sidebar ); ?>">
-			<header class="article-header">
-				<?php get_template_part( 'partials/single/meta-area' ); ?>
-				<h1 id="article-title" class="article-title"><?php the_title(); ?></h1>
-			</header>
 
-			<article class="article-content" aria-labelledby="article-title">
-				<?php amnesty_the_content(); ?>
-			</article>
+	<div class="container has-gutter">
+		<div class="article-container">
+			<section class="article <?php echo esc_attr( $article_has_sidebar ); ?>">
+				<header class="article-header">
+					<?php get_template_part( 'partials/single/meta-area' ); ?>
+					<h1 id="article-title" class="article-title"><?php the_title(); ?></h1>
+				</header>
 
-			<footer class="article-footer">
-				<?php get_template_part( 'partials/single/term-area' ); ?>
-			</footer>
-		</section>
+				<article class="article-content" aria-labelledby="article-title">
+					<?php amnesty_the_content(); ?>
+				</article>
 
-	<?php if ( empty( $max_post_content ) ) : ?>
-		<aside class="article-sidebar" aria-label="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ echo esc_attr( _x( 'Sidebar', 'Post Type Singular Name', 'amnesty' ) ); ?>">
-			<?php get_sidebar(); ?>
-		</aside>
-	<?php endif; ?>
+				<footer class="article-footer">
+					<?php get_template_part( 'partials/single/term-area' ); ?>
+				</footer>
+			</section>
+
+		<?php if ( empty( $max_post_content ) ) : ?>
+			<aside class="article-sidebar" aria-label="<?php /* translators: [front] https://wordpresstheme.amnesty.org/the-theme/global-elements/m004-social-share/ */ echo esc_attr( _x( 'Sidebar', 'Post Type Singular Name', 'amnesty' ) ); ?>">
+				<?php get_sidebar(); ?>
+			</aside>
+		<?php endif; ?>
+		</div>
 	</div>
 </main>
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2916

In conjunction with:
- https://github.com/amnestywebsite/wp-plugin-theme-companion/pull/51
- https://github.com/amnestywebsite/sharepoint-runner/pull/33

**Steps to test**:
1. checkout branch and run `yarn build`
2. visit each of the urls listed below
3. for each of the urls:
4. the hero/featured slider (if present) should still be the full width of the container
5. all other content should be indented horizontally by 40px

- /get-involved/
- /get-involved/take-action/
- /who-we-are/
- /latest/
- /latest/news/
- /latest/education/
- /latest/campaigns/
- /latest/impact/
- /latest/research/
- /search/
- /search/[search-term]/
- /countries/
- /location/africa/
- /location/africa/east-africa-the-horn-and-great-lakes/
- /location/africa/east-africa-the-horn-and-great-lakes/democratic-republic-of-the-congo/
