### PR TITLE
Hide the LWI block from the inserter

### DIFF
--- a/private/src/scripts/editor/blocks/links-with-icons/index.jsx
+++ b/private/src/scripts/editor/blocks/links-with-icons/index.jsx
@@ -22,6 +22,7 @@ registerBlockType('amnesty-core/repeatable-block', {
   supports: {
     className: true,
     defaultStylePicker: false,
+    inserter: false,
   },
 
   attributes: {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/120

**Steps to test**:
1. edit a post
2. try to insert a "Links with Icons" block
3. you should be unable to do so
