### PR TITLE
Enable and style core/gallery block

### DIFF
--- a/private/src/scripts/editor/block-filters/hide-unused-blocks.js
+++ b/private/src/scripts/editor/block-filters/hide-unused-blocks.js
@@ -20,7 +20,6 @@ const unusedBlocks = [
   'core/file',
   'core/footnotes',
   'core/freeform',
-  'core/gallery',
   'core/latest-comments',
   'core/loginout',
   'core/media-text',

--- a/private/src/scripts/editor/block-filters/toggle-image-block-metadata.jsx
+++ b/private/src/scripts/editor/block-filters/toggle-image-block-metadata.jsx
@@ -3,6 +3,7 @@ const { assign } = lodash;
 const { createHigherOrderComponent } = wp.compose;
 const { InspectorControls } = wp.blockEditor;
 const { PanelBody, ToggleControl } = wp.components;
+const { useSelect } = wp.data;
 const { useEffect, useRef, useState } = wp.element;
 const { addFilter } = wp.hooks;
 const { __ } = wp.i18n;
@@ -42,6 +43,14 @@ const fetchImageData = (id, setState) => {
 
 const ImageBlockWrapper = createHigherOrderComponent((DisplayComponent) => (props) => {
   if (props.name !== 'core/image') {
+    return <DisplayComponent {...props} />;
+  }
+
+  const isNestedBlock = useSelect((select) => {
+    return select('core/block-editor').getBlockParents(props.clientId).length > 0;
+  });
+
+  if (isNestedBlock) {
     return <DisplayComponent {...props} />;
   }
 

--- a/private/src/scripts/editor/block-filters/toggle-image-block-metadata.jsx
+++ b/private/src/scripts/editor/block-filters/toggle-image-block-metadata.jsx
@@ -41,6 +41,25 @@ const fetchImageData = (id, setState) => {
   });
 };
 
+const Controls = ({ attributes, setAttributes }) => (
+  <InspectorControls>
+    <PanelBody>
+      <ToggleControl
+        // translators: [admin]
+        label={__('Hide Image Caption', 'amnesty')}
+        checked={attributes.hideImageCaption}
+        onChange={(hideImageCaption) => setAttributes({ hideImageCaption })}
+      />
+      <ToggleControl
+        // translators: [admin]
+        label={__('Hide Image Credit', 'amnesty')}
+        checked={attributes.hideImageCopyright}
+        onChange={(hideImageCopyright) => setAttributes({ hideImageCopyright })}
+      />
+    </PanelBody>
+  </InspectorControls>
+);
+
 const ImageBlockWrapper = createHigherOrderComponent((DisplayComponent) => (props) => {
   if (props.name !== 'core/image') {
     return <DisplayComponent {...props} />;
@@ -50,13 +69,18 @@ const ImageBlockWrapper = createHigherOrderComponent((DisplayComponent) => (prop
     return select('core/block-editor').getBlockParents(props.clientId).length > 0;
   });
 
-  if (isNestedBlock) {
-    return <DisplayComponent {...props} />;
-  }
-
   const { attributes, setAttributes } = props;
   const [imageData, setImageData] = useState(null);
   const blockRef = useRef(null);
+
+  if (isNestedBlock) {
+    return (
+      <>
+        <DisplayComponent {...props} />
+        <Controls attributes={attributes} setAttributes={setAttributes} />
+      </>
+    );
+  }
 
   const shouldShowImageCaption =
     imageData?.caption &&
@@ -99,22 +123,7 @@ const ImageBlockWrapper = createHigherOrderComponent((DisplayComponent) => (prop
           </div>
         )}
       </div>
-      <InspectorControls>
-        <PanelBody>
-          <ToggleControl
-            // translators: [admin]
-            label={__('Hide Image Caption', 'amnesty')}
-            checked={attributes.hideImageCaption}
-            onChange={(hideImageCaption) => setAttributes({ hideImageCaption })}
-          />
-          <ToggleControl
-            // translators: [admin]
-            label={__('Hide Image Credit', 'amnesty')}
-            checked={attributes.hideImageCopyright}
-            onChange={(hideImageCopyright) => setAttributes({ hideImageCopyright })}
-          />
-        </PanelBody>
-      </InspectorControls>
+      <Controls attributes={attributes} setAttributes={setAttributes} />
     </>
   );
 });

--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -105,6 +105,7 @@
 @import "blocks/text-media/main";
 @import "blocks/tweet-action/tweet";
 @import "blocks/tabbed-content/main";
+@import "blocks/core-blocks/gallery";
 
 // Block patterns
 @import "block-patterns/social-share";

--- a/private/src/styles/blocks/core-blocks/_gallery-editor.scss
+++ b/private/src/styles/blocks/core-blocks/_gallery-editor.scss
@@ -1,0 +1,3 @@
+.wp-block-gallery figcaption {
+  display: none;
+}

--- a/private/src/styles/blocks/core-blocks/_gallery.scss
+++ b/private/src/styles/blocks/core-blocks/_gallery.scss
@@ -8,3 +8,11 @@
 .wp-block-gallery figcaption {
   display: none;
 }
+
+.wp-block-gallery .wp-block-image .image-metadataItem.image-caption {
+  display: none;
+}
+
+.wp-block-gallery .wp-block-image.enlarged-image .image-metadataItem.image-caption {
+  display: block;
+}

--- a/private/src/styles/blocks/core-blocks/_gallery.scss
+++ b/private/src/styles/blocks/core-blocks/_gallery.scss
@@ -1,0 +1,10 @@
+.wp-block-gallery-is-layout-flex {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.wp-block-gallery figcaption {
+  display: none;
+}

--- a/private/src/styles/gutenberg.scss
+++ b/private/src/styles/gutenberg.scss
@@ -95,6 +95,7 @@
 @import "blocks/tweet-action/tweet";
 @import "blocks/tweet-action/editor";
 @import "blocks/tabbed-content/editor";
+@import "blocks/core-blocks/gallery-editor";
 
 // Block Patterns
 @import "block-patterns/social-share";


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/225 https://github.com/amnestywebsite/wp-plugin-amnesty-branding/issues/24

**Steps to test**:
1. Edit a post
2. Insert a gallery block from the block inserter
3. Add images making sure they have credit and captions
4. Check the gallery displays correctly (Credits and Captions should not show in the editor)
5. Select image block, ensure credits and captions are not hidden (toggles) and toggle on expand on click
6. Save and view the front end
7. Gallery should display as expected, with only credits showing on each image
8. Now expand an image, the caption AND credit should display when enlarged
9. Go back to the editor, play around with the number of columns, ensuring the editor and front end change accordingly
10. All captions and credits should have the correct font applied

Example: http://bigbite.im/v/e0mF2B
