### PR TITLE
Re-enable core/details and remove collapsable block

### DIFF
--- a/private/src/scripts/editor/block-filters/hide-unused-blocks.js
+++ b/private/src/scripts/editor/block-filters/hide-unused-blocks.js
@@ -16,7 +16,6 @@ const unusedBlocks = [
   'core/comment-reply-link',
   'core/comment-template',
   'core/cover',
-  'core/details',
   'core/file',
   'core/footnotes',
   'core/freeform',
@@ -55,6 +54,7 @@ const unusedBlocks = [
   'core/term-description',
   'core/verse',
   'amnesty-core/image-block',
+  'amnesty-core/collapsable',
 ];
 
 /**


### PR DESCRIPTION
Adds the core details block back into the block inserter and removes the collapsable block

Ref: https://github.com/amnestywebsite/humanity-theme/issues/228

**Steps to test**:
1. Edit a post
2. Open the block inserter
3. Search for Details, and the core Details block should appear and be insertable
4. Search for Collapsable and the custom Collapsable block should not appear

Example: 
http://bigbite.im/i/FFcjfm
http://bigbite.im/i/or9R4l
