### PR TITLE
Details Block Humanity Styles

### DIFF
--- a/private/src/scripts/editor/block-filters/hide-unused-blocks.js
+++ b/private/src/scripts/editor/block-filters/hide-unused-blocks.js
@@ -16,7 +16,6 @@ const unusedBlocks = [
   'core/comment-reply-link',
   'core/comment-template',
   'core/cover',
-  'core/details',
   'core/file',
   'core/footnotes',
   'core/freeform',
@@ -55,6 +54,7 @@ const unusedBlocks = [
   'core/term-description',
   'core/verse',
   'amnesty-core/image-block',
+  'amnesty-core/collapsable',
 ];
 
 /**

--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -105,6 +105,7 @@
 @import "blocks/text-media/main";
 @import "blocks/tweet-action/tweet";
 @import "blocks/tabbed-content/main";
+@import "blocks/core-blocks/details";
 
 // Block patterns
 @import "block-patterns/social-share";

--- a/private/src/styles/blocks/core-blocks/_details.scss
+++ b/private/src/styles/blocks/core-blocks/_details.scss
@@ -2,9 +2,9 @@
   display: flex;
   padding: spacing(half) 0;
   border-bottom: 1px solid $color-black;
-  color: #262626;
+  color: $color-grey-dark;
   line-height: 1.12;
-  font-family: var(--font-family-secondary);
+  font-family: var(--wp--preset--font-family--secondary);
   font-size: map-get($desktop-header-sizes, "h3");
   margin-bottom: spacing(half);
   align-items: center;

--- a/private/src/styles/blocks/core-blocks/_details.scss
+++ b/private/src/styles/blocks/core-blocks/_details.scss
@@ -1,0 +1,23 @@
+.wp-block-details summary {
+  display: flex;
+  padding: spacing(half) 0;
+  border-bottom: 1px solid $color-black;
+  color: #262626;
+  line-height: 1.12;
+  font-family: var(--font-family-secondary);
+  font-size: map-get($desktop-header-sizes, "h3");
+  margin-bottom: spacing(half);
+  align-items: center;
+  justify-content: space-between;
+
+  &::after {
+    @include icon-scaled(271px, 215px, 16px, 16px, 1.5);
+    position: relative;
+    content: "";
+    transition: transform 0.3s ease-in-out, -webkit-transform 0.3s ease-in-out;
+  }
+}
+
+.wp-block-details[open] summary::after {
+  transform: rotate(180deg);
+}

--- a/private/src/styles/gutenberg.scss
+++ b/private/src/styles/gutenberg.scss
@@ -95,6 +95,7 @@
 @import "blocks/tweet-action/tweet";
 @import "blocks/tweet-action/editor";
 @import "blocks/tabbed-content/editor";
+@import "blocks/core-blocks/details";
 
 // Block Patterns
 @import "block-patterns/social-share";


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/231

Style the Core Details block to match the old custom Collapsable block

**Steps to test**:
1. Edit a post
2. Add both a Detail block and Collapsable block (Collapsable has been hidden from the block insterter so use code view to add <!-- wp:amnesty-core/collapsable -->)
3. Ensure both look the same in terms of styles both in the editor and on the front end

Example: http://bigbite.im/v/DusKN5
