### PR TITLE
Add a transforms.to within the custom collapsable block

### DIFF
--- a/private/src/scripts/editor/block-filters/hide-unused-blocks.js
+++ b/private/src/scripts/editor/block-filters/hide-unused-blocks.js
@@ -16,7 +16,6 @@ const unusedBlocks = [
   'core/comment-reply-link',
   'core/comment-template',
   'core/cover',
-  'core/details',
   'core/file',
   'core/footnotes',
   'core/freeform',
@@ -55,6 +54,7 @@ const unusedBlocks = [
   'core/term-description',
   'core/verse',
   'amnesty-core/image-block',
+  'amnesty-core/collapsable',
 ];
 
 /**

--- a/private/src/scripts/editor/blocks/collapsable/index.jsx
+++ b/private/src/scripts/editor/blocks/collapsable/index.jsx
@@ -2,7 +2,7 @@ import DisplayComponent from './DisplayComponent.jsx';
 
 const { assign } = lodash;
 const { InnerBlocks } = wp.blockEditor;
-const { registerBlockType } = wp.blocks;
+const { registerBlockType, createBlock } = wp.blocks;
 const { __ } = wp.i18n;
 
 registerBlockType('amnesty-core/collapsable', {
@@ -38,6 +38,23 @@ registerBlockType('amnesty-core/collapsable', {
       type: 'string',
       default: '',
     },
+  },
+  transforms: {
+    to: [
+      {
+        type: 'block',
+        blocks: ['core/details'],
+        transform: ({ collapsed, title }, innerBlocks) =>
+          createBlock(
+            'core/details',
+            {
+              showContent: !collapsed,
+              summary: title,
+            },
+            innerBlocks,
+          ),
+      },
+    ],
   },
   edit: DisplayComponent,
   save: assign(() => <InnerBlocks.Content />, { displayName: 'CollapsableBlockSave' }),


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/229

Adds a transform.to to the JS block registration of the custom collapsable block to allow it to be changed to a core/details block while retaining the attributes and innerBlocks

**Steps to test**:
1. Edit a post
2. Add a collapsable block (This is now hidden from the block inserter so will need to be added via code editor <!-- wp:amnesty-core/collapsable -->)
3. Save the post and refresh, now click the block icon in the block toolbar and notice Details appears in the transform options
4. Click Details in the options and the collapsable block should change to a Details block while retaining all the content and attributes

Example: http://bigbite.im/v/vVSMnE
