### PR TITLE
Block Templates - Web Report

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/web-report.php
+++ b/wp-content/themes/humanity-theme/patterns/web-report.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * Title: Web Report
+ * Description: A full post pattern for a Web Report
+ * Slug: amnesty/web-report
+ * Keywords: full, web report
+ * Categories: humanity-media, humanity-two-column, humanity-sixtysix-thirtythree
+ */
+?>
+
+<!-- wp:amnesty-core/hero {"content":"","title":"Web report","align":"left"} /-->
+
+<!-- wp:amnesty-core/block-menu {"color":"dark","type":"inpage-menu"} /-->
+
+<!-- wp:amnesty-core/block-section {"background":"","sectionId":"executivesummary","sectionName":"Executive Summary"} -->
+<!-- wp:heading {"textAlign":"center","className":"wp-block-heading"} -->
+<h2 class="wp-block-heading has-text-align-center" id="h-executive-summary">Executive Summary</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut nec quam et ante gravida molestie ut ac lorem. Suspendisse sed lorem faucibus, euismod dolor non, malesuada mauris. Praesent tincidunt blandit dolor, sed convallis urna sollicitudin et. Vestibulum iaculis ante sit amet augue interdum convallis. Vivamus molestie dignissim erat auctor venenatis. Nulla a tristique tortor. Integer scelerisque venenatis orci blandit porta. Morbi pellentesque leo id bibendum dapibus. Nullam vestibulum elementum elementum.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Proin tincidunt accumsan nisi, eu viverra tellus mollis pharetra. Integer viverra aliquam tellus, sit amet euismod nulla auctor sit amet. Vivamus iaculis finibus euismod. Mauris egestas a dui et sodales. Etiam at arcu arcu. Donec lorem leo, tincidunt id consectetur in, ultrices eu nibh. Nulla pellentesque imperdiet odio, laoreet suscipit dui dictum et. Vivamus viverra neque ac massa accumsan feugiat. Ut venenatis metus ut metus porttitor, in ultrices augue sodales. Duis hendrerit vel diam at pretium. Cras rhoncus sollicitudin neque at tristique. Suspendisse blandit orci ac quam tempus, vel feugiat lorem commodo. Praesent nec ultrices orci, sed cursus nisl. Aliquam erat volutpat. Nunc ligula nisl, convallis ac odio sed, vulputate eleifend urna. Ut fermentum quis ipsum a facilisis.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Donec ex mauris, feugiat blandit tempor eu, fermentum quis turpis. Duis at magna magna. Mauris dapibus metus est, in congue dolor consectetur eu. Morbi vestibulum sapien vel mi maximus aliquet. Nulla sit amet sapien quis diam cursus posuere fringilla ut ante. Integer sed purus a felis aliquam condimentum sed vitae arcu. Morbi nec accumsan elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec sem eu dolor egestas feugiat at in magna. Cras sollicitudin euismod eros vitae congue. Pellentesque mattis egestas tellus, et pulvinar magna condimentum eu. Donec fringilla nulla sit amet tincidunt ultrices. Nunc mattis lectus id feugiat mollis. Donec dapibus, dolor id fermentum rhoncus, tellus risus vehicula sapien, in malesuada orci velit at odio.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Ut id ex eget orci pulvinar pulvinar. Aliquam pretium magna orci, nec vulputate massa blandit id. Sed blandit euismod luctus. Vestibulum id mauris nec lorem gravida bibendum ut nec erat. Aenean ante elit, cursus sed vulputate ut, pulvinar eu mauris. Mauris eget scelerisque tellus. Suspendisse nisi quam, condimentum eu luctus quis, congue gravida odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec ullamcorper dolor leo, vitae rhoncus tortor tempus ut. Praesent ullamcorper, nibh at malesuada pulvinar, risus magna ultricies quam, a scelerisque enim est vitae leo. Donec quis gravida arcu, in porta leo. Curabitur ultrices ligula diam, non placerat lacus tempus nec.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse consequat fermentum sem. Phasellus cursus velit diam. Praesent et elementum tellus, eget consequat tellus. Curabitur commodo justo quis massa tempus bibendum. Phasellus ultrices eu urna at congue. Pellentesque non elit vel ante iaculis accumsan. Suspendisse placerat magna vel nibh dignissim, id imperdiet est suscipit. Quisque ornare nisl velit, non mattis risus luctus sed. Integer venenatis quam ac malesuada varius.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"textAlign":"center","className":"wp-block-heading"} -->
+<h2 class="wp-block-heading has-text-align-center" id="h-conclusion-and-recommendations">Conclusion and recommendations</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut nec quam et ante gravida molestie ut ac lorem. Suspendisse sed lorem faucibus, euismod dolor non, malesuada mauris. Praesent tincidunt blandit dolor, sed convallis urna sollicitudin et. Vestibulum iaculis ante sit amet augue interdum convallis. Vivamus molestie dignissim erat auctor venenatis. Nulla a tristique tortor. Integer scelerisque venenatis orci blandit porta. Morbi pellentesque leo id bibendum dapibus. Nullam vestibulum elementum elementum.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3,"className":"wp-block-heading"} -->
+<h3 class="wp-block-heading" id="h-key-recommendations-to-the-serbian-government">Key recommendations </h3>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut nec quam et ante gravida molestie ut ac lorem. Suspendisse sed lorem faucibus, euismod dolor non, malesuada mauris. </li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Praesent tincidunt blandit dolor, sed convallis urna sollicitudin et. Vestibulum iaculis ante sit amet augue interdum convallis. Vivamus molestie dignissim erat auctor venenatis. Nulla a tristique tortor. </li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Integer scelerisque venenatis orci blandit porta. Morbi pellentesque leo id bibendum dapibus. Nullam vestibulum elementum elementum.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Proin tincidunt accumsan nisi, eu viverra tellus mollis pharetra. Integer viverra aliquam tellus, sit amet euismod nulla auctor sit amet. Vivamus iaculis finibus euismod. Mauris egestas a dui et sodales. Etiam at arcu arcu. Donec lorem leo, tincidunt id consectetur in, ultrices eu nibh. </li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Nulla pellentesque imperdiet odio, laoreet suscipit dui dictum et. Vivamus viverra neque ac massa accumsan feugiat. Ut venenatis metus ut metus porttitor, in ultrices augue sodales. </li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Duis hendrerit vel diam at pretium. Cras rhoncus sollicitudin neque at tristique. Suspendisse blandit orci ac quam tempus, vel feugiat lorem commodo. Praesent nec ultrices orci, sed cursus nisl. Aliquam erat volutpat. Nunc ligula nisl, convallis ac odio sed, vulputate eleifend urna. Ut fermentum quis ipsum a facilisis.</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+<!-- /wp:amnesty-core/block-section -->
+
+<!-- wp:amnesty-core/block-section {"background":"grey"} -->
+<!-- wp:amnesty-core/collapsable {"collapsed":true,"title":"Methodology"} -->
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut nec quam et ante gravida molestie ut ac lorem. Suspendisse sed lorem faucibus, euismod dolor non, malesuada mauris. Praesent tincidunt blandit dolor, sed convallis urna sollicitudin et. Vestibulum iaculis ante sit amet augue interdum convallis. Vivamus molestie dignissim erat auctor venenatis. Nulla a tristique tortor. Integer scelerisque venenatis orci blandit porta. Morbi pellentesque leo id bibendum dapibus. Nullam vestibulum elementum elementum.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Proin tincidunt accumsan nisi, eu viverra tellus mollis pharetra. Integer viverra aliquam tellus, sit amet euismod nulla auctor sit amet. Vivamus iaculis finibus euismod. Mauris egestas a dui et sodales. Etiam at arcu arcu. Donec lorem leo, tincidunt id consectetur in, ultrices eu nibh. Nulla pellentesque imperdiet odio, laoreet suscipit dui dictum et. Vivamus viverra neque ac massa accumsan feugiat. Ut venenatis metus ut metus porttitor, in ultrices augue sodales. Duis hendrerit vel diam at pretium. Cras rhoncus sollicitudin neque at tristique. Suspendisse blandit orci ac quam tempus, vel feugiat lorem commodo. Praesent nec ultrices orci, sed cursus nisl. Aliquam erat volutpat. Nunc ligula nisl, convallis ac odio sed, vulputate eleifend urna. Ut fermentum quis ipsum a facilisis.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Donec ex mauris, feugiat blandit tempor eu, fermentum quis turpis. Duis at magna magna. Mauris dapibus metus est, in congue dolor consectetur eu. Morbi vestibulum sapien vel mi maximus aliquet. Nulla sit amet sapien quis diam cursus posuere fringilla ut ante. Integer sed purus a felis aliquam condimentum sed vitae arcu. Morbi nec accumsan elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec sem eu dolor egestas feugiat at in magna. Cras sollicitudin euismod eros vitae congue. Pellentesque mattis egestas tellus, et pulvinar magna condimentum eu. Donec fringilla nulla sit amet tincidunt ultrices. Nunc mattis lectus id feugiat mollis. Donec dapibus, dolor id fermentum rhoncus, tellus risus vehicula sapien, in malesuada orci velit at odio.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Ut id ex eget orci pulvinar pulvinar. Aliquam pretium magna orci, nec vulputate massa blandit id. Sed blandit euismod luctus. Vestibulum id mauris nec lorem gravida bibendum ut nec erat. Aenean ante elit, cursus sed vulputate ut, pulvinar eu mauris. Mauris eget scelerisque tellus. Suspendisse nisi quam, condimentum eu luctus quis, congue gravida odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec ullamcorper dolor leo, vitae rhoncus tortor tempus ut. Praesent ullamcorper, nibh at malesuada pulvinar, risus magna ultricies quam, a scelerisque enim est vitae leo. Donec quis gravida arcu, in porta leo. Curabitur ultrices ligula diam, non placerat lacus tempus nec.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse consequat fermentum sem. Phasellus cursus velit diam. Praesent et elementum tellus, eget consequat tellus. Curabitur commodo justo quis massa tempus bibendum. Phasellus ultrices eu urna at congue. Pellentesque non elit vel ante iaculis accumsan. Suspendisse placerat magna vel nibh dignissim, id imperdiet est suscipit. Quisque ornare nisl velit, non mattis risus luctus sed. Integer venenatis quam ac malesuada varius.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut nec quam et ante gravida molestie ut ac lorem. Suspendisse sed lorem faucibus, euismod dolor non, malesuada mauris. Praesent tincidunt blandit dolor, sed convallis urna sollicitudin et. Vestibulum iaculis ante sit amet augue interdum convallis. Vivamus molestie dignissim erat auctor venenatis. Nulla a tristique tortor. Integer scelerisque venenatis orci blandit porta. Morbi pellentesque leo id bibendum dapibus. Nullam vestibulum elementum elementum.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Proin tincidunt accumsan nisi, eu viverra tellus mollis pharetra. Integer viverra aliquam tellus, sit amet euismod nulla auctor sit amet. Vivamus iaculis finibus euismod. Mauris egestas a dui et sodales. Etiam at arcu arcu. Donec lorem leo, tincidunt id consectetur in, ultrices eu nibh. Nulla pellentesque imperdiet odio, laoreet suscipit dui dictum et. Vivamus viverra neque ac massa accumsan feugiat. Ut venenatis metus ut metus porttitor, in ultrices augue sodales. Duis hendrerit vel diam at pretium. Cras rhoncus sollicitudin neque at tristique. Suspendisse blandit orci ac quam tempus, vel feugiat lorem commodo. Praesent nec ultrices orci, sed cursus nisl. Aliquam erat volutpat. Nunc ligula nisl, convallis ac odio sed, vulputate eleifend urna. Ut fermentum quis ipsum a facilisis.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Donec ex mauris, feugiat blandit tempor eu, fermentum quis turpis. Duis at magna magna. Mauris dapibus metus est, in congue dolor consectetur eu. Morbi vestibulum sapien vel mi maximus aliquet. Nulla sit amet sapien quis diam cursus posuere fringilla ut ante. Integer sed purus a felis aliquam condimentum sed vitae arcu. Morbi nec accumsan elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec sem eu dolor egestas feugiat at in magna. Cras sollicitudin euismod eros vitae congue. Pellentesque mattis egestas tellus, et pulvinar magna condimentum eu. Donec fringilla nulla sit amet tincidunt ultrices. Nunc mattis lectus id feugiat mollis. Donec dapibus, dolor id fermentum rhoncus, tellus risus vehicula sapien, in malesuada orci velit at odio.</p>
+<!-- /wp:paragraph -->
+<!-- /wp:amnesty-core/collapsable -->
+<!-- /wp:amnesty-core/block-section -->
+
+<!-- wp:spacer -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:amnesty-core/block-section -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:amnesty-core/block-section {"background":"grey","sectionId":"chapter1","sectionName":"Chapter 1","backgroundImageOrigin":"center"} -->
+<!-- wp:heading {"textAlign":"center","fontSize":"x-large"} -->
+<h2 class="wp-block-heading has-text-align-center has-x-large-font-size">Chapter 1 – Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;</h2>
+<!-- /wp:heading -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button" href="#">subsection 1</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button" href="#">subsection 2</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+<!-- /wp:amnesty-core/block-section --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Heading 3 - Subsection 1</h3>
+<!-- /wp:heading --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut nec quam et ante gravida molestie ut ac lorem. Suspendisse sed lorem faucibus, euismod dolor non, malesuada mauris. Praesent tincidunt blandit dolor, sed convallis urna sollicitudin et. Vestibulum iaculis ante sit amet augue interdum convallis. Vivamus molestie dignissim erat auctor venenatis. Nulla a tristique tortor. Integer scelerisque venenatis orci blandit porta. Morbi pellentesque leo id bibendum dapibus. Nullam vestibulum elementum elementum.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Proin tincidunt accumsan nisi, eu viverra tellus mollis pharetra. Integer viverra aliquam tellus, sit amet euismod nulla auctor sit amet. Vivamus iaculis finibus euismod. Mauris egestas a dui et sodales. Etiam at arcu arcu. Donec lorem leo, tincidunt id consectetur in, ultrices eu nibh. Nulla pellentesque imperdiet odio, laoreet suscipit dui dictum et. Vivamus viverra neque ac massa accumsan feugiat. Ut venenatis metus ut metus porttitor, in ultrices augue sodales. Duis hendrerit vel diam at pretium. Cras rhoncus sollicitudin neque at tristique. Suspendisse blandit orci ac quam tempus, vel feugiat lorem commodo. Praesent nec ultrices orci, sed cursus nisl. Aliquam erat volutpat. Nunc ligula nisl, convallis ac odio sed, vulputate eleifend urna. Ut fermentum quis ipsum a facilisis.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Donec ex mauris, feugiat blandit tempor eu, fermentum quis turpis. Duis at magna magna. Mauris dapibus metus est, in congue dolor consectetur eu. Morbi vestibulum sapien vel mi maximus aliquet. Nulla sit amet sapien quis diam cursus posuere fringilla ut ante. Integer sed purus a felis aliquam condimentum sed vitae arcu. Morbi nec accumsan elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec sem eu dolor egestas feugiat at in magna. Cras sollicitudin euismod eros vitae congue. Pellentesque mattis egestas tellus, et pulvinar magna condimentum eu. Donec fringilla nulla sit amet tincidunt ultrices. Nunc mattis lectus id feugiat mollis. Donec dapibus, dolor id fermentum rhoncus, tellus risus vehicula sapien, in malesuada orci velit at odio.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Heading 3 – Subsection 2</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Ut id ex eget orci pulvinar pulvinar. Aliquam pretium magna orci, nec vulputate massa blandit id. Sed blandit euismod luctus. Vestibulum id mauris nec lorem gravida bibendum ut nec erat. Aenean ante elit, cursus sed vulputate ut, pulvinar eu mauris. Mauris eget scelerisque tellus. Suspendisse nisi quam, condimentum eu luctus quis, congue gravida odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec ullamcorper dolor leo, vitae rhoncus tortor tempus ut. Praesent ullamcorper, nibh at malesuada pulvinar, risus magna ultricies quam, a scelerisque enim est vitae leo. Donec quis gravida arcu, in porta leo. Curabitur ultrices ligula diam, non placerat lacus tempus nec.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse consequat fermentum sem. Phasellus cursus velit diam. Praesent et elementum tellus, eget consequat tellus. Curabitur commodo justo quis massa tempus bibendum. Phasellus ultrices eu urna at congue. Pellentesque non elit vel ante iaculis accumsan. Suspendisse placerat magna vel nibh dignissim, id imperdiet est suscipit. Quisque ornare nisl velit, non mattis risus luctus sed. Integer venenatis quam ac malesuada varius.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:amnesty-core/collapsable {"collapsed":true,"title":"Footnotes"} -->
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+<!-- /wp:amnesty-core/collapsable -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-light"} -->
+<div class="wp-block-button is-style-light"><a class="wp-block-button__link wp-element-button" href="#">back to top</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:amnesty-core/block-section -->
+
+<!-- wp:amnesty-core/block-section -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:amnesty-core/block-section {"background":"grey","sectionId":"chapter2","sectionName":"Chapter 2"} -->
+<!-- wp:heading {"textAlign":"center","fontSize":"x-large"} -->
+<h2 class="wp-block-heading has-text-align-center has-x-large-font-size">Chapter 2 – Lorem ipsum dolor sit amet, consectetur adipiscing elit.&nbsp;</h2>
+<!-- /wp:heading -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button" href="#">subsection 1</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button" href="#">subsection 2</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+<!-- /wp:amnesty-core/block-section --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Heading 3 - Subsection 1</h3>
+<!-- /wp:heading --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut nec quam et ante gravida molestie ut ac lorem. Suspendisse sed lorem faucibus, euismod dolor non, malesuada mauris. Praesent tincidunt blandit dolor, sed convallis urna sollicitudin et. Vestibulum iaculis ante sit amet augue interdum convallis. Vivamus molestie dignissim erat auctor venenatis. Nulla a tristique tortor. Integer scelerisque venenatis orci blandit porta. Morbi pellentesque leo id bibendum dapibus. Nullam vestibulum elementum elementum.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Proin tincidunt accumsan nisi, eu viverra tellus mollis pharetra. Integer viverra aliquam tellus, sit amet euismod nulla auctor sit amet. Vivamus iaculis finibus euismod. Mauris egestas a dui et sodales. Etiam at arcu arcu. Donec lorem leo, tincidunt id consectetur in, ultrices eu nibh. Nulla pellentesque imperdiet odio, laoreet suscipit dui dictum et. Vivamus viverra neque ac massa accumsan feugiat. Ut venenatis metus ut metus porttitor, in ultrices augue sodales. Duis hendrerit vel diam at pretium. Cras rhoncus sollicitudin neque at tristique. Suspendisse blandit orci ac quam tempus, vel feugiat lorem commodo. Praesent nec ultrices orci, sed cursus nisl. Aliquam erat volutpat. Nunc ligula nisl, convallis ac odio sed, vulputate eleifend urna. Ut fermentum quis ipsum a facilisis.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Donec ex mauris, feugiat blandit tempor eu, fermentum quis turpis. Duis at magna magna. Mauris dapibus metus est, in congue dolor consectetur eu. Morbi vestibulum sapien vel mi maximus aliquet. Nulla sit amet sapien quis diam cursus posuere fringilla ut ante. Integer sed purus a felis aliquam condimentum sed vitae arcu. Morbi nec accumsan elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec sem eu dolor egestas feugiat at in magna. Cras sollicitudin euismod eros vitae congue. Pellentesque mattis egestas tellus, et pulvinar magna condimentum eu. Donec fringilla nulla sit amet tincidunt ultrices. Nunc mattis lectus id feugiat mollis. Donec dapibus, dolor id fermentum rhoncus, tellus risus vehicula sapien, in malesuada orci velit at odio.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading">Heading 3 – Subsection 2</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Ut id ex eget orci pulvinar pulvinar. Aliquam pretium magna orci, nec vulputate massa blandit id. Sed blandit euismod luctus. Vestibulum id mauris nec lorem gravida bibendum ut nec erat. Aenean ante elit, cursus sed vulputate ut, pulvinar eu mauris. Mauris eget scelerisque tellus. Suspendisse nisi quam, condimentum eu luctus quis, congue gravida odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec ullamcorper dolor leo, vitae rhoncus tortor tempus ut. Praesent ullamcorper, nibh at malesuada pulvinar, risus magna ultricies quam, a scelerisque enim est vitae leo. Donec quis gravida arcu, in porta leo. Curabitur ultrices ligula diam, non placerat lacus tempus nec.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse consequat fermentum sem. Phasellus cursus velit diam. Praesent et elementum tellus, eget consequat tellus. Curabitur commodo justo quis massa tempus bibendum. Phasellus ultrices eu urna at congue. Pellentesque non elit vel ante iaculis accumsan. Suspendisse placerat magna vel nibh dignissim, id imperdiet est suscipit. Quisque ornare nisl velit, non mattis risus luctus sed. Integer venenatis quam ac malesuada varius.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:amnesty-core/collapsable {"collapsed":true,"title":"Footnotes"} -->
+<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->
+<!-- /wp:amnesty-core/collapsable -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-light"} -->
+<div class="wp-block-button is-style-light"><a class="wp-block-button__link wp-element-button" href="#">back to top</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:amnesty-core/block-section -->
+
+<!-- wp:amnesty-core/block-section {"sectionId":"conclusionandrecommendations","sectionName":"Conclusion and Recommendations"} -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:amnesty-core/block-section {"background":"grey"} -->
+<!-- wp:heading {"textAlign":"center","fontSize":"x-large"} -->
+<h2 class="wp-block-heading has-text-align-center has-x-large-font-size">Conclusion and Recommendations</h2>
+<!-- /wp:heading -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button" href="#">Recommendations</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->
+<!-- /wp:amnesty-core/block-section --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut nec quam et ante gravida molestie ut ac lorem. Suspendisse sed lorem faucibus, euismod dolor non, malesuada mauris. Praesent tincidunt blandit dolor, sed convallis urna sollicitudin et. Vestibulum iaculis ante sit amet augue interdum convallis. Vivamus molestie dignissim erat auctor venenatis. Nulla a tristique tortor. Integer scelerisque venenatis orci blandit porta. Morbi pellentesque leo id bibendum dapibus. Nullam vestibulum elementum elementum.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Proin tincidunt accumsan nisi, eu viverra tellus mollis pharetra. Integer viverra aliquam tellus, sit amet euismod nulla auctor sit amet. Vivamus iaculis finibus euismod. Mauris egestas a dui et sodales. Etiam at arcu arcu. Donec lorem leo, tincidunt id consectetur in, ultrices eu nibh. Nulla pellentesque imperdiet odio, laoreet suscipit dui dictum et. Vivamus viverra neque ac massa accumsan feugiat. Ut venenatis metus ut metus porttitor, in ultrices augue sodales. Duis hendrerit vel diam at pretium. Cras rhoncus sollicitudin neque at tristique. Suspendisse blandit orci ac quam tempus, vel feugiat lorem commodo. Praesent nec ultrices orci, sed cursus nisl. Aliquam erat volutpat. Nunc ligula nisl, convallis ac odio sed, vulputate eleifend urna. Ut fermentum quis ipsum a facilisis.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Donec ex mauris, feugiat blandit tempor eu, fermentum quis turpis. Duis at magna magna. Mauris dapibus metus est, in congue dolor consectetur eu. Morbi vestibulum sapien vel mi maximus aliquet. Nulla sit amet sapien quis diam cursus posuere fringilla ut ante. Integer sed purus a felis aliquam condimentum sed vitae arcu. Morbi nec accumsan elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec sem eu dolor egestas feugiat at in magna. Cras sollicitudin euismod eros vitae congue. Pellentesque mattis egestas tellus, et pulvinar magna condimentum eu. Donec fringilla nulla sit amet tincidunt ultrices. Nunc mattis lectus id feugiat mollis. Donec dapibus, dolor id fermentum rhoncus, tellus risus vehicula sapien, in malesuada orci velit at odio.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator {"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading {"level":3} -->
+<h3 class="wp-block-heading" id="h-recommendations">Recommendations to...</h3>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut nec quam et ante gravida molestie ut ac lorem. Suspendisse sed lorem faucibus, euismod dolor non, malesuada mauris. Praesent tincidunt blandit dolor, sed convallis urna sollicitudin et. Vestibulum iaculis ante sit amet augue interdum convallis. Vivamus molestie dignissim erat auctor venenatis. Nulla a tristique tortor. Integer scelerisque venenatis orci blandit porta. Morbi pellentesque leo id bibendum dapibus. Nullam vestibulum elementum elementum.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>Proin tincidunt accumsan nisi, eu viverra tellus mollis pharetra. Integer viverra aliquam tellus, sit amet euismod nulla auctor sit amet. Vivamus iaculis finibus euismod. Mauris egestas a dui et sodales. </li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Etiam at arcu arcu. Donec lorem leo, tincidunt id consectetur in, ultrices eu nibh. Nulla pellentesque imperdiet odio, laoreet suscipit dui dictum et. Vivamus viverra neque ac massa accumsan feugiat. Ut venenatis metus ut metus porttitor, in ultrices augue sodales. </li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Duis hendrerit vel diam at pretium. Cras rhoncus sollicitudin neque at tristique. Suspendisse blandit orci ac quam tempus, vel feugiat lorem commodo. Praesent nec ultrices orci, sed cursus nisl. Aliquam erat volutpat. Nunc ligula nisl, convallis ac odio sed, vulputate eleifend urna. </li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Ut fermentum quis ipsum a facilisis.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Donec ex mauris, feugiat blandit tempor eu, fermentum quis turpis. Duis at magna magna. Mauris dapibus metus est, in congue dolor consectetur eu. Morbi vestibulum sapien vel mi maximus aliquet. Nulla sit amet sapien quis diam cursus posuere fringilla ut ante. Integer sed purus a felis aliquam condimentum sed vitae arcu. Morbi nec accumsan elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec sem eu dolor egestas feugiat at in magna. Cras sollicitudin euismod eros vitae congue. Pellentesque mattis egestas tellus, et pulvinar magna condimentum eu. Donec fringilla nulla sit amet tincidunt ultrices. Nunc mattis lectus id feugiat mollis. Donec dapibus, dolor id fermentum rhoncus, tellus risus vehicula sapien, in malesuada orci velit at odio.</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:separator {"className":"is-style-wide"} -->
+<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+<!-- /wp:separator -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button" href="#">back to top</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:amnesty-core/block-section -->


### PR DESCRIPTION
Updates the web report block pattern to output the chapter heading/links inside a 66 column

Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2932

**Steps to test**:
1. Edit a post
2. Open the block inserter and switch to the patterns tab
3. Look for the Web Report pattern and insert it
4. Chapter sections, and the Conclusion section should now be within a 66% column instead of full width

Example: http://bigbite.im/i/YUBZ8e
