### PR TITLE
Re-enables the footnotes block

### DIFF
--- a/private/src/scripts/editor/block-filters/hide-unused-blocks.js
+++ b/private/src/scripts/editor/block-filters/hide-unused-blocks.js
@@ -18,7 +18,6 @@ const unusedBlocks = [
   'core/cover',
   'core/details',
   'core/file',
-  'core/footnotes',
   'core/freeform',
   'core/gallery',
   'core/latest-comments',


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/243

Adds support for the core/footnotes block, although footnotes is not used within the block inserter, removed it from the function that hides blocks from the inserter as it is not needed

**Steps to test**:
1. Edit a post
2. Enter a bunch of text content (Headings, Paragraphs etc)
3. Place your cursor somewhere in a paragraph, and click the dropdown arrow in the block toolbar
4. You should see "Footnote" as an option, select it
5. A new footnote will be added to the bottom of the post for you to enter text.
6. Create a few footnotes, save and view the front end

Example: http://bigbite.im/i/pYNklF
