### PR TITLE
Re-enable core/cover block

### DIFF
--- a/private/src/scripts/editor/block-filters/disable-blocks.js
+++ b/private/src/scripts/editor/block-filters/disable-blocks.js
@@ -1,7 +1,0 @@
-const { unregisterBlockType } = wp.blocks;
-
-const disabledBlocks = ['core/cover'];
-
-wp.domReady(() => {
-  disabledBlocks.forEach(unregisterBlockType);
-});

--- a/private/src/scripts/editor/block-filters/hide-unused-blocks.js
+++ b/private/src/scripts/editor/block-filters/hide-unused-blocks.js
@@ -15,7 +15,6 @@ const unusedBlocks = [
   'core/comment-edit-link',
   'core/comment-reply-link',
   'core/comment-template',
-  'core/cover',
   'core/details',
   'core/file',
   'core/footnotes',

--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -85,6 +85,7 @@
 @import "blocks/core-blocks/social-links";
 @import "blocks/core-blocks/table";
 @import "blocks/core-blocks/video";
+@import "blocks/core-blocks/cover";
 @import "blocks/countdown-timer/main";
 @import "blocks/custom-card/main";
 @import "blocks/download-block/style";

--- a/private/src/styles/blocks/core-blocks/_cover.scss
+++ b/private/src/styles/blocks/core-blocks/_cover.scss
@@ -1,0 +1,4 @@
+.wp-block-cover .wp-block-cover__image-background img {
+  object-fit: cover;
+  width: 100%;
+}


### PR DESCRIPTION
Issue: 

Re-enables the core/cover block and adds some styles to ensure the background image covers the whole block

**Steps to test**:
1. Edit a post
2. Open the block inserter and search "Cover"
3. Core/cover block should be available
4. Insert the block, add a background image and some text
5. Save the post and view the front end
6. Background image should cover the whole block

Example: http://bigbite.im/i/BbPGtZ