### PR TITLE
Re-enables the core audio block on the theme

### DIFF
--- a/private/src/scripts/editor/block-filters/hide-unused-blocks.js
+++ b/private/src/scripts/editor/block-filters/hide-unused-blocks.js
@@ -5,7 +5,6 @@ const unusedNamespaces = ['yoast', 'yoast-seo', 'woocommerce'];
 
 const unusedBlocks = [
   'core/archives',
-  'core/audio',
   'core/avatar',
   'core/calendar',
   'core/categories',


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/263

Re-enables the core audio block on the theme

**Steps to test**:
1. Edit a post
2. Open the block inserter and search "Audio"
3. The core/audio block should be available

Example: http://bigbite.im/i/eYzsPN
