### PR TITLE
Audio/Quote Block Patterns

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/audio-quote.php
+++ b/wp-content/themes/humanity-theme/patterns/audio-quote.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Title: Quote with Audio above it
+ * Description: A quote block with an audio block above it.
+ * Slug: amnesty/audio-quote
+ * Keywords: quote, audio
+ * Categories: humanity-media
+ */
+?>
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:audio /-->
+
+<!-- wp:amnesty-core/quote {"align":"","content":"","citation":""} /--></div>
+<!-- /wp:group -->

--- a/wp-content/themes/humanity-theme/patterns/audio-transcript.php
+++ b/wp-content/themes/humanity-theme/patterns/audio-transcript.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Title: Audio with Transcript
+ * Description: An Audio block with a Details block for a transcript below it.
+ * Slug: amnesty/audio-transcript
+ * Keywords: audio, transcript
+ * Categories: humanity-media
+ */
+?>
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:audio /-->
+
+<!-- wp:details -->
+<details class="wp-block-details"><summary>Transcript</summary><!-- wp:paragraph {"placeholder":"Type / to add a hidden block"} -->
+<p></p>
+<!-- /wp:paragraph --></details>
+<!-- /wp:details --></div>
+<!-- /wp:group -->

--- a/wp-content/themes/humanity-theme/patterns/quote-audio.php
+++ b/wp-content/themes/humanity-theme/patterns/quote-audio.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Title: Quote with Audio below it
+ * Description: A quote block with an audio block below it.
+ * Slug: amnesty/quote-audio
+ * Keywords: quote, audio
+ * Categories: humanity-media
+ */
+?>
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:amnesty-core/quote {"align":"","content":"","citation":""} /-->
+
+<!-- wp:audio /--></div>
+<!-- /wp:group -->


### PR DESCRIPTION
Ref: #261 

Creates 3 new patterns for the audio block, 2 with quote blocks (above and below the audio) and one with a details block below to be used for the audio transcript

**Steps to test**:
1. Edit a post
2. Open the block inserter and change the Patterns tab
3. Under the Media category, there should be 3 new patterns related to the Audio block
4. Insert all the patterns, populate with content
5. View them in the editor and the front end to ensure they work correctly and display as expected

Example: http://bigbite.im/v/EZsMev
