### PR TITLE
Fix white space below Header/Hero block

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/_deprecated/header/class-header-block-renderer.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/_deprecated/header/class-header-block-renderer.php
@@ -20,6 +20,11 @@ if ( ! function_exists( '\Amnesty\Blocks\amnesty_render_header_block' ) ) {
 	 * @return string
 	 */
 	function amnesty_render_header_block( array $attributes = [], string $content = '' ): string {
+		// if imageID is not set, return an empty string
+		if ( ! isset( $attributes['imageID'] ) ) {
+			return '';
+		}
+
 		$renderer = new Header_Block_Renderer( $attributes, $content );
 		return $renderer->render();
 	}
@@ -183,11 +188,6 @@ class Header_Block_Renderer {
 			]
 		);
 
-		// Only render header if there is an image
-		if ( 0 === $this->attributes['imageID'] ) {
-			return;
-		}
-
 		printf(
 			'<div id="banner-%s" class="%s" role="region">',
 			esc_attr( $this->id ),
@@ -227,11 +227,6 @@ class Header_Block_Renderer {
 
 		if ( $this->content ) {
 			$classes .= ' has-donation-block';
-		}
-
-		// Only render header if there is an image
-		if ( 0 === $this->attributes['imageID'] ) {
-			return;
 		}
 
 		printf( '<div class="container"><div class="%s">', esc_attr( $classes ) );

--- a/wp-content/themes/humanity-theme/includes/blocks/_deprecated/header/class-header-block-renderer.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/_deprecated/header/class-header-block-renderer.php
@@ -229,6 +229,11 @@ class Header_Block_Renderer {
 			$classes .= ' has-donation-block';
 		}
 
+		// Only render header if there is an image
+		if ( 0 === $this->attributes['imageID'] ) {
+			return;
+		}
+
 		printf( '<div class="container"><div class="%s">', esc_attr( $classes ) );
 	}
 

--- a/wp-content/themes/humanity-theme/includes/blocks/_deprecated/header/class-header-block-renderer.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/_deprecated/header/class-header-block-renderer.php
@@ -183,6 +183,11 @@ class Header_Block_Renderer {
 			]
 		);
 
+		// Only render header if there is an image
+		if ( $this->attributes['imageID'] === 0 ) {
+			return;
+		}
+
 		printf(
 			'<div id="banner-%s" class="%s" role="region">',
 			esc_attr( $this->id ),

--- a/wp-content/themes/humanity-theme/includes/blocks/_deprecated/header/class-header-block-renderer.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/_deprecated/header/class-header-block-renderer.php
@@ -184,7 +184,7 @@ class Header_Block_Renderer {
 		);
 
 		// Only render header if there is an image
-		if ( $this->attributes['imageID'] === 0 ) {
+		if ( 0 === $this->attributes['imageID'] ) {
 			return;
 		}
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/272

Adds a conditional check to make sure the header/hero has an image ID before outputting, preventing an empty block being output which was causing a large amount of white space

**Steps to test**:
1. Edit the latest page
2. Insert a header block using the code editor (or by checking out a branch without the new hero block first)
3. Save and switch to this branch
4. Open Latest on the front end
5. The hero/header should display correctly with no white space/empty block

Example: http://bigbite.im/i/5Es2hI
