### PR TITLE
Fix issue with Hero CTA button link

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/hero/views/hero.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/hero/views/hero.php
@@ -37,8 +37,7 @@ $background_image = wp_get_attachment_image_url( $image_id, 'hero-md' );
 		<?php if ( $attrs['ctaText'] || $attrs['ctaLink'] ) : ?>
 			<div class="hero-cta">
 				<div class="btn btn--large">
-					<span><?php echo wp_kses_post( $attrs['ctaText'] ); ?></span>
-					<a href="<?php echo esc_url( $attrs['ctaLink'] ); ?>"></a>
+					<a href="<?php echo esc_url( $attrs['ctaLink'] ); ?>"><?php echo wp_kses_post( $attrs['ctaText'] ); ?></a>
 				</div>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2957

**Steps to test**:
1. before checking out this branch
2. add a hero block including a cta with a link
3. view the frontend
4. try clicking the button
5. it should do nothing
6. switch to this branch
7. reload the frontend
8. click the button
9. it should go to the link defined
