### PR TITLE
Fix visibility issues with Post List content fields

### DIFF
--- a/private/src/styles/components/grid/_editor.scss
+++ b/private/src/styles/components/grid/_editor.scss
@@ -46,6 +46,10 @@
   font-family: var(--wp--preset--font-family--primary);
 }
 
+.grid-itemContent .components-button svg {
+  fill: unset;
+}
+
 .linkList-options {
   position: absolute;
   z-index: 10;

--- a/private/src/styles/components/grid/_item.scss
+++ b/private/src/styles/components/grid/_item.scss
@@ -98,22 +98,6 @@ h3.grid-itemTitle > a {
   left: 0;
 }
 
-.grid-itemContent {
-  position: relative;
-  display: none;
-  overflow: hidden;
-  max-width: 100%;
-}
-
-.no-js .grid-item:hover .grid-itemContent,
-.no-js .grid-item:focus .grid-itemContent {
-  display: block;
-}
-
-.no-js .grid-item:focus-within .grid-itemContent {
-  display: block;
-}
-
 .grid {
   display: grid;
   row-gap: 20px;


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/279

**Steps to test**:
1. add a post list block in the editor
2. set it to grid mode
3. set it to "custom" content type
4. you should be able to see the tag and title fields
5. add some text into both the tag and title fields, and their respective links
6. once links have been added, you should still be able to see the link icon in the button (previously it appeared to be a blank white box)
7. save the post and view the frontend
8. you should be able to see the post list block
9. you should be able to see both the tag and title content items within the block
10. clicking the tag should take you to the link you set
11. clicking the title should take you to the link you set
