### PR TITLE
Removes Pop In from Header Template Part

### DIFF
--- a/wp-content/themes/humanity-theme/parts/header.html
+++ b/wp-content/themes/humanity-theme/parts/header.html
@@ -1,4 +1,1 @@
-<!-- wp:amnesty-core/pop-in -->
-<!-- wp:amnesty-core/action-block {"centred":true,"label":"Take Action","content":"Action Content","imageID":0,"imageURL":"https://unsplash.com/photos/c6FwhJFUyoI/download?ixid=M3wxMjA3fDB8MXxzZWFyY2h8MTZ8fHNoaXB3cmVja3xlbnwwfHx8fDE3MTM4OTE4MDd8MA&force=true&w=640","imageAlt":"Shipwreck photo by zhao chen on Unsplash","link":"#","linkText":"Take Action"} /-->
-<!-- /wp:amnesty-core/pop-in -->
 <!-- wp:amnesty-core/site-header /-->


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/277

Removes pop in and action block from the header template part

**Steps to test**:
1. View the 404 page
2. There should no longer be a pop in or action block within the header

Example: http://bigbite.im/i/wbCwRY
