### PR TITLE
Latest Posts Sidebar Padding Issue

### DIFF
--- a/private/src/styles/blocks/core-blocks/_latest-posts.scss
+++ b/private/src/styles/blocks/core-blocks/_latest-posts.scss
@@ -1,7 +1,7 @@
 .wp-block-latest-posts.wp-block-latest-posts__list {
   background-color: $color-grey-light;
   margin-left: 0;
-  padding: 24px;
+  padding: 24px !important;
   width: 100%;
 }
 

--- a/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
@@ -59,9 +59,7 @@ if ( ! function_exists( 'amnesty_styles' ) ) {
 
 		$theme = wp_get_theme();
 
-		$style_deps = [
-			// 'wp-block-latest-posts', -- causes issues on some sites
-		];
+		$style_deps = [];
 
 		if ( wp_style_is( 'woocommerce-general' ) ) {
 			$style_deps[] = 'woocommerce-general';


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/274

Removes a style dependency for the latest posts block and adds an !important to our padding to ensure it is applied to all sides

**Steps to test**:
1. Add the latest posts block to a sidebar
2. Add the sidebar to a post
3. Save and view the front end
4. The latest posts block should have equal and even padding on all sides with no content being cut off

Example: http://bigbite.im/i/ILjhWt