### PR TITLE
Correct the Code of Conduct link in the Contributing file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for considering contributing to our project! We welcome all manner of 
 
 ## How can I contribute?
 
-We expect all contributors to abide by our [Code of Conduct](https://github.com/amnestywebsite/humanity-theme/CODE_OF_CONDUCT.md), so please familiarise yourself with that first.
+We expect all contributors to abide by our [Code of Conduct](https://github.com/amnestywebsite/humanity-theme/blob/main/CODE_OF_CONDUCT.md), so please familiarise yourself with that first.
 
 How would you like to contribute?
 - writing code? See our [developer guide](https://github.com/amnestywebsite/humanity-theme/blob/main/docs/contributors/code.md)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -16,4 +16,4 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-You can view the full license text in [LICENSE.txt](https://github.com/amnestywebsite/humanity-theme/blob/main/LICENSE.text).
+You can view the full license text in [LICENSE.txt](https://github.com/amnestywebsite/humanity-theme/blob/main/LICENSE.txt).


### PR DESCRIPTION
Ref: N/A

The `Code of Conduct` link was pointing to the incorrect location, thus making it less accessible from the `CONTRIBUTING.md` file. This PR fixes that by pointing it to the correct file and location on the `main` branch, keeping it inline with other documentation links within the file.

An incorrect file extension in the `LICENSE.md` file has also been corrected to ensure that the url is pointing to the correct full licensing text.

**Steps to test**:
1. N/A
