### PR TITLE
Fix pathing on Windows in Webpack config

### DIFF
--- a/private/webpack.config.js
+++ b/private/webpack.config.js
@@ -50,9 +50,9 @@ const getPlugins = (argv, env) => {
       patterns: [
         {
           context: SRC_PATH,
-          from: 'static/**/*',
+          from: path.resolve(SRC_PATH, 'static'),
           to({ absoluteFilename }) {
-            return absoluteFilename.replace(`${SRC_PATH}/static`, OUT_PATH);
+            return absoluteFilename.replace(path.resolve(SRC_PATH, 'static'), OUT_PATH);
           },
         },
       ],


### PR DESCRIPTION
Ref: N/A

**Steps to test**:
1. on a Windows machine, checkout the repo (with LF line endings only)
2. cd into `.\private`
3. run `yarn`
4. run `yarn build`
5. it should succeed without errors or warnings
6. assets within the `[repo]\private\src\static\` dir should copy to `[repo]\wp-content\themes\humanity-theme\assets\` dir
