### PR TITLE
Add missing viewport meta tags

### DIFF
--- a/wp-content/themes/humanity-theme/header.php
+++ b/wp-content/themes/humanity-theme/header.php
@@ -10,6 +10,8 @@
 <!DOCTYPE html>
 <html class="no-js" <?php language_attributes(); ?>>
 <head>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/276

**Steps to test**:
1. install browser-sync (`npm i -g browser-sync`)
2. proxy your local environment with browser-sync (`browser-sync start --proxy https://your-domain.tld`)
3. with a phone connected to the same network, visit the access url specified by browser-sync
4. you should see that the site does not respond to your browser width
5. checkout this branch
6. reload the page
7. you should see the small-device layout
