### PR TITLE
Custom Card Block Pattern

### DIFF
--- a/private/src/scripts/editor/block-styles/group-block.js
+++ b/private/src/scripts/editor/block-styles/group-block.js
@@ -6,3 +6,15 @@ registerBlockStyle('core/group', {
   // translators: [admin]
   label: _x('Square Border', 'block style', 'amnesty'),
 });
+
+registerBlockStyle('core/group', {
+  name: 'light',
+  // translators: [admin]
+  label: _x('Light Background', 'block style', 'amnesty'),
+});
+
+registerBlockStyle('core/group', {
+  name: 'dark',
+  // translators: [admin]
+  label: _x('Dark Background', 'block style', 'amnesty'),
+});

--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -111,6 +111,7 @@
 
 // Block patterns
 @import "block-patterns/social-share";
+@import "block-patterns/group";
 
 // Pages
 @import "pages/404";

--- a/private/src/styles/block-patterns/_group.scss
+++ b/private/src/styles/block-patterns/_group.scss
@@ -1,0 +1,36 @@
+.wp-block-group.custom-card {
+  max-width: 350px !important;
+
+  .wp-block-buttons {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+
+  .wp-block-buttons,
+  .wp-block-button,
+  .wp-block-button__link {
+    width: 100%;
+  }
+
+  .wp-block-heading {
+    text-transform: uppercase;
+  }
+}
+
+.wp-block-group.custom-card.alignfull {
+  max-width: 480px !important;
+}
+
+.wp-block-group.is-style-light {
+  background-color: var(--wp--preset--color--amnesty-grey-x-light);
+  color: var(--wp--preset--color--black);
+}
+
+.wp-block-group.is-style-dark {
+  background-color: var(--wp--preset--color--amnesty-grey-mid-dark);
+  color: var(--wp--preset--color--white);
+
+  .wp-block-heading {
+    color: var(--wp--preset--color--white);
+  }
+}

--- a/private/src/styles/block-patterns/_group.scss
+++ b/private/src/styles/block-patterns/_group.scss
@@ -14,6 +14,16 @@
 
   .wp-block-heading {
     text-transform: uppercase;
+    font-size: 1.5rem;
+  }
+
+  p {
+    font-size: 1rem;
+    padding: 10px 10px 0 10px;
+  }
+
+  .wp-element-caption {
+    padding: 0 10px;
   }
 }
 
@@ -30,7 +40,8 @@
   background-color: var(--wp--preset--color--amnesty-grey-mid-dark);
   color: var(--wp--preset--color--white);
 
-  .wp-block-heading {
+  .wp-block-heading,
+  .wp-element-caption {
     color: var(--wp--preset--color--white);
   }
 }

--- a/private/src/styles/gutenberg.scss
+++ b/private/src/styles/gutenberg.scss
@@ -108,6 +108,7 @@
 
 // Block Patterns
 @import "block-patterns/social-share";
+@import "block-patterns/group";
 
 :root {
   --ms-base: 16;

--- a/wp-content/themes/humanity-theme/patterns/custom-card-dark.php
+++ b/wp-content/themes/humanity-theme/patterns/custom-card-dark.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Custom Card Dark
+ * Description: Custom card with a dark grey background containing a heading, image, paragraph, and button.
+ * Slug: amnesty/custom-card-dark
+ * Keywords: custom, card, dark, grey
+ * Categories: humanity-actions
+ */
+?>
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"className":"custom-card is-style-dark","layout":{"type":"constrained","contentSize":"350px","wideSize":"480px"}} -->
+<div class="wp-block-group custom-card is-style-dark" style="padding-top:8px;padding-bottom:8px"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="wp-block-heading has-text-align-center">(Label)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"hideImageCopyright":true} -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Content</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button" href="#">Button</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->

--- a/wp-content/themes/humanity-theme/patterns/custom-card-light.php
+++ b/wp-content/themes/humanity-theme/patterns/custom-card-light.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Custom Card Light
+ * Description: Custom card with a light grey background containing a heading, image, paragraph, and button.
+ * Slug: amnesty/custom-card-light
+ * Keywords: custom, card, light, grey
+ * Categories: humanity-actions
+ */
+?>
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"className":"custom-card is-style-light","layout":{"type":"constrained","contentSize":"350px","wideSize":"480px"}} -->
+<div class="wp-block-group custom-card is-style-light" style="padding-top:8px;padding-bottom:8px"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="wp-block-heading has-text-align-center">(Label)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"hideImageCopyright":true} -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Content</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button" href="#">Button</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/287

Creates two new block patterns to replace the custom card block on the theme

**Steps to test**:
1. Edit a post
2. Open the block inserter
3. There should now be 2 patterns for a "Light" and "Dark" custom cards
4. Insert both and check they display correctly in the editor and on the front end
5. Return to the editor and highlight the group block, notice 2 new blocks styles for light and dark
6. Use the alignment dropdown in the block toolbar to change between regular and wide block pattern variations

Branding patterns and block styles can be found in branding plugin PR [here](https://github.com/amnestywebsite/wp-plugin-amnesty-branding/pull/41).

Example: http://bigbite.im/v/WnXOBg
