### PR TITLE
Call To Action Block Pattern

### DIFF
--- a/private/src/scripts/editor/block-styles/group-block.js
+++ b/private/src/scripts/editor/block-styles/group-block.js
@@ -18,3 +18,9 @@ registerBlockStyle('core/group', {
   // translators: [admin]
   label: _x('Dark Background', 'block style', 'amnesty'),
 });
+
+registerBlockStyle('core/group', {
+  name: 'top-and-bottom-border',
+  // translators: [admin]
+  label: _x('Top and Bottom Border', 'block style', 'amnesty'),
+});

--- a/private/src/scripts/editor/block-styles/group-block.js
+++ b/private/src/scripts/editor/block-styles/group-block.js
@@ -6,3 +6,15 @@ registerBlockStyle('core/group', {
   // translators: [admin]
   label: _x('Square Border', 'block style', 'amnesty'),
 });
+
+registerBlockStyle('core/group', {
+  name: 'light',
+  // translators: [admin]
+  label: _x('Light Background', 'block style', 'amnesty'),
+});
+
+registerBlockStyle('core/group', {
+  name: 'dark',
+  // translators: [admin]
+  label: _x('Dark Background', 'block style', 'amnesty'),
+});

--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -111,6 +111,7 @@
 
 // Block patterns
 @import "block-patterns/social-share";
+@import "block-patterns/group";
 
 // Pages
 @import "pages/404";

--- a/private/src/styles/block-patterns/_group.scss
+++ b/private/src/styles/block-patterns/_group.scss
@@ -34,3 +34,18 @@
     color: var(--wp--preset--color--white);
   }
 }
+
+.wp-block-group.call-to-action {
+  margin-top: 40px;
+  padding: 20px;
+  text-align: center;
+
+  @include mq(small) {
+    padding: 36px 32px;
+  }
+}
+
+.wp-block-group.is-style-top-and-bottom-border {
+  border-top: 7px solid var(--wp--preset--color--black);
+  border-bottom: 7px solid var(--wp--preset--color--black);
+}

--- a/private/src/styles/block-patterns/_group.scss
+++ b/private/src/styles/block-patterns/_group.scss
@@ -1,0 +1,36 @@
+.wp-block-group.custom-card {
+  max-width: 350px !important;
+
+  .wp-block-buttons {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+
+  .wp-block-buttons,
+  .wp-block-button,
+  .wp-block-button__link {
+    width: 100%;
+  }
+
+  .wp-block-heading {
+    text-transform: uppercase;
+  }
+}
+
+.wp-block-group.custom-card.alignfull {
+  max-width: 480px !important;
+}
+
+.wp-block-group.is-style-light {
+  background-color: var(--wp--preset--color--amnesty-grey-x-light);
+  color: var(--wp--preset--color--black);
+}
+
+.wp-block-group.is-style-dark {
+  background-color: var(--wp--preset--color--amnesty-grey-mid-dark);
+  color: var(--wp--preset--color--white);
+
+  .wp-block-heading {
+    color: var(--wp--preset--color--white);
+  }
+}

--- a/private/src/styles/gutenberg.scss
+++ b/private/src/styles/gutenberg.scss
@@ -108,6 +108,7 @@
 
 // Block Patterns
 @import "block-patterns/social-share";
+@import "block-patterns/group";
 
 :root {
   --ms-base: 16;

--- a/wp-content/themes/humanity-theme/patterns/call-to-action-borders.php
+++ b/wp-content/themes/humanity-theme/patterns/call-to-action-borders.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Title: Call to Action Borders
+ * Description: Call to action with a top and bottom border containing a headings, paragraph, and button.
+ * Slug: amnesty/call-to-action-borders
+ * Keywords: call to action, borders
+ * Categories: humanity-actions
+ */
+?>
+
+<!-- wp:group {"className":"is-style-top-and-bottom-border call-to-action","layout":{"type":"constrained"}} -->
+<div class="wp-block-group is-style-top-and-bottom-border call-to-action"><!-- wp:heading {"textAlign":"center","className":"callToAction-preHeading"} -->
+<h2 class="wp-block-heading has-text-align-center callToAction-preHeading">(Pre-Heading)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"textAlign":"center","className":"callToAction-heading"} -->
+<h2 class="wp-block-heading has-text-align-center callToAction-heading">(Heading)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","className":"callToAction-content"} -->
+<p class="has-text-align-center callToAction-content">(Content)</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button /--></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->

--- a/wp-content/themes/humanity-theme/patterns/call-to-action-grey.php
+++ b/wp-content/themes/humanity-theme/patterns/call-to-action-grey.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Title: Call to Action Grey
+ * Description: Call to action with a grey background containing headings, paragraph, and button.
+ * Slug: amnesty/call-to-action-grey
+ * Keywords: call to action, grey
+ * Categories: humanity-actions
+ */
+?>
+
+<!-- wp:group {"className":"is-style-light call-to-action","layout":{"type":"constrained"}} -->
+<div class="wp-block-group is-style-light call-to-action"><!-- wp:heading {"textAlign":"center","className":"callToAction-preHeading"} -->
+<h2 class="wp-block-heading has-text-align-center callToAction-preHeading">(Pre-Heading)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"textAlign":"center","className":"callToAction-heading"} -->
+<h2 class="wp-block-heading has-text-align-center callToAction-heading">(Heading)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"align":"center","className":"callToAction-content"} -->
+<p class="has-text-align-center callToAction-content">(Content)</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button /--></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->

--- a/wp-content/themes/humanity-theme/patterns/custom-card-dark.php
+++ b/wp-content/themes/humanity-theme/patterns/custom-card-dark.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Custom Card Dark
+ * Description: Custom card with a dark grey background containing a heading, image, paragraph, and button.
+ * Slug: amnesty/custom-card-dark
+ * Keywords: custom, card, dark, grey
+ * Categories: humanity-actions
+ */
+?>
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"className":"custom-card is-style-dark","layout":{"type":"constrained","contentSize":"350px","wideSize":"480px"}} -->
+<div class="wp-block-group custom-card is-style-dark" style="padding-top:8px;padding-bottom:8px"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="wp-block-heading has-text-align-center">(Label)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"hideImageCopyright":true} -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Content</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button" href="#">Button</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->

--- a/wp-content/themes/humanity-theme/patterns/custom-card-light.php
+++ b/wp-content/themes/humanity-theme/patterns/custom-card-light.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Title: Custom Card Light
+ * Description: Custom card with a light grey background containing a heading, image, paragraph, and button.
+ * Slug: amnesty/custom-card-light
+ * Keywords: custom, card, light, grey
+ * Categories: humanity-actions
+ */
+?>
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"className":"custom-card is-style-light","layout":{"type":"constrained","contentSize":"350px","wideSize":"480px"}} -->
+<div class="wp-block-group custom-card is-style-light" style="padding-top:8px;padding-bottom:8px"><!-- wp:heading {"textAlign":"center"} -->
+<h2 class="wp-block-heading has-text-align-center">(Label)</h2>
+<!-- /wp:heading -->
+
+<!-- wp:image {"hideImageCopyright":true} -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"align":"center"} -->
+<p class="has-text-align-center">Content</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-default"} -->
+<div class="wp-block-button is-style-default"><a class="wp-block-button__link wp-element-button" href="#">Button</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group -->


### PR DESCRIPTION
Ref: [#288](https://github.com/amnestywebsite/humanity-theme/issues/288)

Adds a new custom block style for the group block for top and bottom borders, this is so it can be used to create the 2 new call to action block patterns which have also been added in this PR

**Steps to test**:
1. Edit a post
2. Open the block inserter and navigate to the patterns tab
3. There should be 2 new patterns for Call To Action (1. with top and bottom borders, 2. no borders and grey background)
4. Insert the patterns and check they display correctly in the editor and on the front end.
5. Highlight the group block of the pattern and notice the new block style

Example: http://bigbite.im/v/4Rf4in