### PR TITLE
Adds Core Quote Block and Styles

### DIFF
--- a/private/src/scripts/editor/blocks/blockquote/index.jsx
+++ b/private/src/scripts/editor/blocks/blockquote/index.jsx
@@ -2,24 +2,8 @@ import DisplayComponent from './DisplayComponent.jsx';
 import deprecated from './deprecated.jsx';
 import transforms from './transforms.jsx';
 
-const { assign } = lodash;
 const { registerBlockType } = wp.blocks;
 const { __ } = wp.i18n;
-
-/**
- * Hide the core blockquote from the list, as we have our own version.
- */
-wp.hooks.addFilter('blocks.registerBlockType', 'amnesty-core', (settings, name) => {
-  if (name === 'core/quote') {
-    return assign({}, settings, {
-      supports: assign({}, settings.supports, {
-        inserter: false,
-      }),
-    });
-  }
-
-  return settings;
-});
 
 registerBlockType('amnesty-core/quote', {
   // translators: [admin]

--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -85,6 +85,7 @@
 @import "blocks/core-blocks/social-links";
 @import "blocks/core-blocks/table";
 @import "blocks/core-blocks/video";
+@import "blocks/core-blocks/quote";
 @import "blocks/countdown-timer/main";
 @import "blocks/custom-card/main";
 @import "blocks/download-block/style";

--- a/private/src/styles/blocks/core-blocks/_quote.scss
+++ b/private/src/styles/blocks/core-blocks/_quote.scss
@@ -1,3 +1,8 @@
+.wp-block-quote,
+.wp-block-quote.is-style-default {
+  border-left: none;
+}
+
 .wp-block-quote::before,
 .wp-block-quote.has-text-align-center::before {
   content: open-quote;

--- a/private/src/styles/blocks/core-blocks/_quote.scss
+++ b/private/src/styles/blocks/core-blocks/_quote.scss
@@ -171,9 +171,8 @@
   display: inline-block;
 }
 
-.wp-block-quote,
 .wp-block-quote.is-style-plain {
-  border: none;
+  border: none !important;
 }
 
 .wp-block-quote.is-style-plain cite::after,

--- a/private/src/styles/blocks/core-blocks/_quote.scss
+++ b/private/src/styles/blocks/core-blocks/_quote.scss
@@ -1,0 +1,64 @@
+.wp-block-quote.has-text-align-center cite::after {
+  content: "";
+  display: block;
+  margin: 8px auto 0;
+  max-width: 80px;
+  height: 8px;
+  background-color: var(--wp--preset--color--black);
+}
+
+.wp-block-quote p,
+.wp-block-quote cite {
+  font-family: var(--wp--preset--font-family--secondary);
+}
+
+.wp-block-quote.has-small-font-size p,
+.wp-block-quote.has-small-font-size cite {
+  font-size: 1.75rem !important;
+}
+
+.wp-block-quote.has-medium-font-size p,
+.wp-block-quote.has-medium-font-size cite {
+  font-size: 2rem !important;
+}
+
+.wp-block-quote.has-large-font-size p,
+.wp-block-quote.has-large-font-size cite {
+  font-size: 2.25rem !important;
+}
+
+.wp-block-quote cite {
+  text-transform: none !important;
+}
+
+.wp-block-quote.wp-block-quote.has-text-align-center {
+  quotes: '“' '”' "‘" "’";
+}
+
+.wp-block-quote.has-text-align-left {
+  border-left: 8px solid var(--wp--preset--color--black);
+}
+
+.wp-block-quote.has-text-align-right {
+  border-right: 8px solid var(--wp--preset--color--black);
+}
+
+.wp-block-quote.has-text-align-left p::before,
+.wp-block-quote.has-text-align-right p::before {
+  content: open-quote;
+  quotes: '“' '”';
+}
+
+.wp-block-quote.has-text-align-left p::after,
+.wp-block-quote.has-text-align-right p::after {
+  content: close-quote;
+  quotes: '“' '”';
+}
+
+.wp-block-quote.is-style-plain {
+  border: none;
+}
+
+.wp-block-quote.is-style-plain cite::after {
+  content: none;
+}

--- a/private/src/styles/blocks/core-blocks/_quote.scss
+++ b/private/src/styles/blocks/core-blocks/_quote.scss
@@ -1,3 +1,10 @@
+.wp-block-quote::before,
+.wp-block-quote.wp-block-quote.has-text-align-center::before {
+  content: open-quote;
+  quotes: '“' '”' "‘" "’";
+}
+
+.wp-block-quote cite::after,
 .wp-block-quote.has-text-align-center cite::after {
   content: "";
   display: block;
@@ -31,16 +38,22 @@
   text-transform: none !important;
 }
 
-.wp-block-quote.wp-block-quote.has-text-align-center {
-  quotes: '“' '”' "‘" "’";
-}
-
 .wp-block-quote.has-text-align-left {
   border-left: 8px solid var(--wp--preset--color--black);
+  padding-left: 27px;
+
+  cite {
+    margin-left: 15px;
+  }
 }
 
 .wp-block-quote.has-text-align-right {
   border-right: 8px solid var(--wp--preset--color--black);
+  padding-right: 27px;
+
+  cite {
+    margin-right: 15px;
+  }
 }
 
 .wp-block-quote.has-text-align-left p::before,
@@ -55,10 +68,18 @@
   quotes: '“' '”';
 }
 
+.wp-block-quote,
 .wp-block-quote.is-style-plain {
   border: none;
 }
 
-.wp-block-quote.is-style-plain cite::after {
+.wp-block-quote.is-style-plain cite::after,
+.wp-block-quote.has-text-align-left cite::after,
+.wp-block-quote.has-text-align-right cite::after {
+  content: none;
+}
+
+.wp-block-quote.wp-block-quote.has-text-align-left::before,
+.wp-block-quote.wp-block-quote.has-text-align-right::before {
   content: none;
 }

--- a/private/src/styles/blocks/core-blocks/_quote.scss
+++ b/private/src/styles/blocks/core-blocks/_quote.scss
@@ -1,5 +1,5 @@
 .wp-block-quote::before,
-.wp-block-quote.wp-block-quote.has-text-align-center::before {
+.wp-block-quote.has-text-align-center::before {
   content: open-quote;
   quotes: '“' '”' "‘" "’";
 }
@@ -18,24 +18,65 @@
   font-family: var(--wp--preset--font-family--secondary);
 }
 
-.wp-block-quote.has-small-font-size p,
-.wp-block-quote.has-small-font-size cite {
+.wp-block-quote.has-small-font-size p {
   font-size: 1.75rem !important;
 }
 
-.wp-block-quote.has-medium-font-size p,
-.wp-block-quote.has-medium-font-size cite {
+.wp-block-quote.has-medium-font-size p {
   font-size: 2rem !important;
 }
 
-.wp-block-quote.has-large-font-size p,
-.wp-block-quote.has-large-font-size cite {
+.wp-block-quote.has-large-font-size p {
   font-size: 2.25rem !important;
 }
 
 .wp-block-quote cite {
   text-transform: none !important;
+
+  @include mq(x-small) {
+    font-size: 1.25rem !important;
+  }
+
+  @include mq(medium) {
+    font-size: 1.5rem !important;
+  }
 }
+
+.wp-block-quote.has-large-font-size cite {
+  @include mq(x-small) {
+    font-size: 1.25rem !important;
+  }
+
+  @include mq(medium) {
+    font-size: 1.5rem !important;
+  }
+}
+
+.wp-block-quote.has-medium-font-size cite {
+  font-size: 1rem !important;
+
+  @include mq(x-small) {
+    font-size: 1.25rem !important;
+  }
+
+  @include mq(medium) {
+    font-size: 1.375rem !important;
+  }
+}
+
+.wp-block-quote.has-small-font-size cite {
+  font-size: 0.875rem !important;
+
+  @include mq(x-small) {
+    font-size: 1.125rem !important;
+  }
+
+  @include mq(medium) {
+    font-size: 1.25rem !important;
+  }
+}
+
+
 
 .wp-block-quote cite::after,
 .wp-block-quote.has-black-color cite::after,
@@ -55,11 +96,7 @@
 
 .wp-block-quote.has-text-align-left {
   border-left: 8px solid var(--wp--preset--color--black);
-  padding-left: 27px;
-
-  cite {
-    margin-left: 15px;
-  }
+  padding-left: 35px;
 }
 
 .wp-block-quote.has-text-align-left.has-white-color {
@@ -72,11 +109,7 @@
 
 .wp-block-quote.has-text-align-right {
   border-right: 8px solid var(--wp--preset--color--black);
-  padding-right: 27px;
-
-  cite {
-    margin-right: 15px;
-  }
+  padding-right: 35px;
 }
 
 .wp-block-quote.has-text-align-right.has-white-color {
@@ -91,12 +124,26 @@
 .wp-block-quote.has-text-align-right p::before {
   content: open-quote;
   quotes: '“' '”';
+  display: inline-block;
+}
+
+.wp-block-quote.has-text-align-left p::before {
+  text-indent: -7px;
+
+  @include mq(medium) {
+    text-indent: -15px;
+  }
+}
+
+.wp-block-quote.has-text-align-right p::after {
+  position: absolute;
 }
 
 .wp-block-quote.has-text-align-left p::after,
 .wp-block-quote.has-text-align-right p::after {
   content: close-quote;
   quotes: '“' '”';
+  display: inline-block;
 }
 
 .wp-block-quote,
@@ -110,7 +157,24 @@
   content: none;
 }
 
-.wp-block-quote.wp-block-quote.has-text-align-left::before,
-.wp-block-quote.wp-block-quote.has-text-align-right::before {
+.wp-block-quote.has-text-align-left::before,
+.wp-block-quote.has-text-align-right::before {
   content: none;
+}
+
+// RTL styles
+.rtl .wp-block-quote.has-text-align-left {
+  text-align: right;
+  border-right: 8px solid var(--wp--preset--color--black);
+  border-left: none;
+  padding-right: 35px;
+  padding-left: 0;
+}
+
+.rtl .wp-block-quote.has-text-align-right {
+  text-align: left;
+  border-left: 8px solid var(--wp--preset--color--black);
+  border-right: none;
+  padding-left: 35px;
+  padding-right: 0;
 }

--- a/private/src/styles/blocks/core-blocks/_quote.scss
+++ b/private/src/styles/blocks/core-blocks/_quote.scss
@@ -11,7 +11,6 @@
   margin: 8px auto 0;
   max-width: 80px;
   height: 8px;
-  background-color: var(--wp--preset--color--black);
 }
 
 .wp-block-quote p,
@@ -38,6 +37,22 @@
   text-transform: none !important;
 }
 
+.wp-block-quote cite::after,
+.wp-block-quote.has-black-color cite::after,
+.wp-block-quote.has-text-align-center.has-black-color cite::after {
+  background-color: var(--wp--preset--color--black);
+}
+
+.wp-block-quote.has-white-color cite::after,
+.wp-block-quote.has-text-align-center.has-white-color cite::after {
+  background-color: var(--wp--preset--color--white);
+}
+
+.wp-block-quote.has-amnesty-grey-brand-color cite::after,
+.wp-block-quote.has-text-align-center.has-amnesty-grey-brand-color cite::after {
+  background-color: var(--wp--preset--color--amnesty-grey-brand);
+}
+
 .wp-block-quote.has-text-align-left {
   border-left: 8px solid var(--wp--preset--color--black);
   padding-left: 27px;
@@ -47,6 +62,14 @@
   }
 }
 
+.wp-block-quote.has-text-align-left.has-white-color {
+  border-left-color: var(--wp--preset--color--white);
+}
+
+.wp-block-quote.has-text-align-left.has-amnesty-grey-brand-color {
+  border-left-color: var(--wp--preset--color--amnesty-grey-brand);
+}
+
 .wp-block-quote.has-text-align-right {
   border-right: 8px solid var(--wp--preset--color--black);
   padding-right: 27px;
@@ -54,6 +77,14 @@
   cite {
     margin-right: 15px;
   }
+}
+
+.wp-block-quote.has-text-align-right.has-white-color {
+  border-right-color: var(--wp--preset--color--white);
+}
+
+.wp-block-quote.has-text-align-right.has-amnesty-grey-brand-color {
+  border-right-color: var(--wp--preset--color--amnesty-grey-brand);
 }
 
 .wp-block-quote.has-text-align-left p::before,

--- a/private/src/styles/blocks/core-blocks/_quote.scss
+++ b/private/src/styles/blocks/core-blocks/_quote.scss
@@ -1,7 +1,6 @@
 .wp-block-quote::before,
 .wp-block-quote.has-text-align-center::before {
   content: open-quote;
-  quotes: '“' '”' "‘" "’";
 }
 
 .wp-block-quote cite::after,
@@ -151,7 +150,6 @@
 .wp-block-quote.has-text-align-left p::before,
 .wp-block-quote.has-text-align-right p::before {
   content: open-quote;
-  quotes: '“' '”';
   display: inline-block;
 }
 
@@ -170,7 +168,6 @@
 .wp-block-quote.has-text-align-left p::after,
 .wp-block-quote.has-text-align-right p::after {
   content: close-quote;
-  quotes: '“' '”';
   display: inline-block;
 }
 

--- a/private/src/styles/blocks/core-blocks/_quote.scss
+++ b/private/src/styles/blocks/core-blocks/_quote.scss
@@ -9,29 +9,57 @@
   content: "";
   display: block;
   margin: 8px auto 0;
-  max-width: 80px;
+  max-width: 200px;
   height: 8px;
+}
+
+.wp-block-quote.has-text-align-center::before {
+  position: absolute;
+  left: 48%;
+  font-family: var(--wp--preset--font-family--secondary) !important;
+  font-weight: bold;
+  font-size: 3.75rem !important;
+  line-height: 1px;
+
+  @include mq(x-small) {
+    font-size: 4.375rem !important;
+  }
+
+  @include mq(medium) {
+    font-size: 5rem !important;
+  }
 }
 
 .wp-block-quote p,
 .wp-block-quote cite {
   font-family: var(--wp--preset--font-family--secondary);
+  margin-bottom: 0;
+}
+
+.wp-block-quote p {
+  font-size: var(--wp--preset--font-size--large) !important;
 }
 
 .wp-block-quote.has-small-font-size p {
-  font-size: 1.75rem !important;
+  font-size: var(--wp--preset--font-size--small) !important;
 }
 
 .wp-block-quote.has-medium-font-size p {
-  font-size: 2rem !important;
+  font-size: var(--wp--preset--font-size--medium) !important;
 }
 
 .wp-block-quote.has-large-font-size p {
-  font-size: 2.25rem !important;
+  font-size: var(--wp--preset--font-size--large) !important;
 }
 
 .wp-block-quote cite {
   text-transform: none !important;
+  display: inline-block;
+  font-style: normal;
+  font-size: 1.125rem !important;
+  font-weight: bold !important;
+  line-height: 40px !important;
+  padding-bottom: 24px;
 
   @include mq(x-small) {
     font-size: 1.25rem !important;

--- a/private/src/styles/editor.scss
+++ b/private/src/styles/editor.scss
@@ -46,6 +46,7 @@
 @import "blocks/core-blocks/menu";
 @import "blocks/core-blocks/rss";
 @import "blocks/core-blocks/social-links";
+@import "blocks/core-blocks/quote";
 @import "blocks/custom-card/main";
 @import "blocks/download-block/style";
 @import "blocks/fact-block/main";

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -29,31 +29,31 @@
         "fluid": true,
         "fontSizes": [
           {
-            "slug": "small",
-            "size": "1.5rem",
-            "name": "Small",
             "fluid": {
               "min": "1rem",
               "max": "1.75rem"
-            }
+            },
+            "slug": "small",
+            "size": "1.75rem",
+            "name": "Small"
           },
           {
-            "slug": "medium",
-            "size": "1.75rem",
-            "name": "Medium",
             "fluid": {
               "min": "1.25rem",
               "max": "2rem"
-            }
+            },
+            "slug": "medium",
+            "size": "2rem",
+            "name": "Medium"
           },
           {
-            "slug": "large",
-            "size": "2rem",
-            "name": "Large",
             "fluid": {
               "min": "1.5rem",
               "max": "2.25rem"
-            }
+            },
+            "slug": "large",
+            "size": "2.25rem",
+            "name": "Large"
           }
         ],
         "textTransform": true

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -26,21 +26,34 @@
         ]
       },
       "typography": {
+        "fluid": true,
         "fontSizes": [
           {
             "slug": "small",
-            "size": "1.75rem",
-            "name": "Small"
+            "size": "1.5rem",
+            "name": "Small",
+            "fluid": {
+              "min": "1rem",
+              "max": "1.75rem"
+            }
           },
           {
             "slug": "medium",
-            "size": "2rem",
-            "name": "Medium"
+            "size": "1.75rem",
+            "name": "Medium",
+            "fluid": {
+              "min": "1.25rem",
+              "max": "2rem"
+            }
           },
           {
             "slug": "large",
-            "size": "2.25rem",
-            "name": "Large"
+            "size": "2rem",
+            "name": "Large",
+            "fluid": {
+              "min": "1.5rem",
+              "max": "2.25rem"
+            }
           }
         ],
         "textTransform": true

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -3,6 +3,50 @@
   "version": 3,
   "settings": {
     "appearanceTools": false,
+    "blocks": {
+    "core/quote": {
+      "color": {
+        "text": true,
+        "palette": [
+          {
+            "slug": "black",
+            "color": "#000",
+            "name": "Black"
+          },
+          {
+            "slug": "white",
+            "color": "#fff",
+            "name": "White"
+          },
+          {
+            "slug": "amnesty-grey_brand",
+            "color": "#b3b3b3",
+            "name": "Grey Brand"
+          }
+        ]
+      },
+      "typography": {
+        "fontSizes": [
+          {
+            "slug": "small",
+            "size": "1.75rem",
+            "name": "Small"
+          },
+          {
+            "slug": "medium",
+            "size": "2rem",
+            "name": "Medium"
+          },
+          {
+            "slug": "large",
+            "size": "2.25rem",
+            "name": "Large"
+          }
+        ],
+        "textTransform": true
+      }
+    }
+  },
     "color": {
       "background": false,
       "text": false,


### PR DESCRIPTION
Ref: #314 

Adds the core/quote block back, adds typography style options (like color palette and font size) into the block via theme.json and adds custom styles

**Steps to test**:
1. Edit a post
2. Open the block inserter and search for quote
3. The core block should now be available
4. Insert it and populate with content
5. Play around with customise options to ensure all functionality from original custom block is available
6. Save and view the front end
7. Now test the transform by checking out the Branding Plugin Branch

Example: http://bigbite.im/v/H9bBd9