### PR TITLE
Example style variation

### DIFF
--- a/wp-content/themes/humanity-theme/styles/blue.json
+++ b/wp-content/themes/humanity-theme/styles/blue.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schemas.wp.org/wp/6.4/theme.json",
+  "version": 2,
+  "settings": {
+    "color": {
+      "palette": [
+        {
+          "slug": "amnesty-primary",
+          "color": "#2196f3",
+          "name": "Primary"
+        },
+        {
+          "slug": "amnesty-primary-state",
+          "color": "#5493be",
+          "name": "Primary State"
+        },
+        {
+          "slug": "amnesty-secondary",
+          "color": "#fdff28",
+          "name": "Secondary"
+        },
+        {
+          "slug": "amnesty-accent",
+          "color": "#f8d72b",
+          "name": "Accent"
+        }
+      ]
+    }
+  }
+}

--- a/wp-content/themes/humanity-theme/styles/blue.json
+++ b/wp-content/themes/humanity-theme/styles/blue.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://schemas.wp.org/wp/6.4/theme.json",
+  "title": "Blue Primary",
   "version": 2,
   "settings": {
     "color": {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/335

This is a small PR to provide an example of an alternative colour scheme using the theme.json format.

After looking through the colour names, I don't think any of these need to be changed. I think the colours with descriptive names (Grey Extra Extra Light, Orange, Blue Mid Light) can stay as they are, as these can likely be used across many different colour variations. 

The ones that could potentially change are: 

- Primary
- Primary State
- Secondary
- Accent

Maybe some other semantic colours could be added if there needs to be more flexibility, but I think it's fine to start with these.

This PR shows an example of switching the Primary and Secondary colours around, and I added a different shade of blue for the Secondary State.

**Steps to test**:
1.

**Considerations**:
- Accessibility
  - Regions (semantic HTML tags, e.g. `<section>`; [landmarks](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#landmark_roles); etc.)
  - Screen reader compatibility, labels ([`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label), [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby), etc.)
  - Keyboard navigability
- Localisation
- RTL
