### PR TITLE
wp-env: activate theme after dev env start

### DIFF
--- a/private/.wp-env.json
+++ b/private/.wp-env.json
@@ -1,4 +1,7 @@
 {
   "themes": ["../wp-content/themes/humanity-theme"],
-  "plugins": ["CMB2/CMB2"]
+  "plugins": ["CMB2/CMB2"],
+  "lifecycleScripts": {
+    "afterStart": "yarn env run cli wp theme activate humanity-theme"
+  }
 }


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/pull/342#pullrequestreview-2221757571

**Steps to test**:
1. Start the dev environment and deactivate the Humanity Theme if already active (Can be done by running `yarn env run cli wp theme activate twentytwentyfour`).
1. Re-start the dev environment using `yarn env start`
1. Humanity Theme should be active after starting.

**Considerations**:
- Accessibility
  - Regions (semantic HTML tags, e.g. `<section>`; [landmarks](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#landmark_roles); etc.)
  - Screen reader compatibility, labels ([`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label), [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby), etc.)
  - Keyboard navigability
- Localisation
- RTL
