### PR TITLE
Adds CMB extensions to wp-env configuration

### DIFF
--- a/private/.wp-env.json
+++ b/private/.wp-env.json
@@ -1,6 +1,12 @@
 {
   "themes": ["../wp-content/themes/humanity-theme"],
-  "plugins": ["CMB2/CMB2"],
+  "plugins": [
+    "CMB2/CMB2",
+    "CMB2/cmb2-attached-posts",
+    "amnestywebsite/cmb2-message-field",
+    "amnestywebsite/cmb2-password-field",
+    "jaymcp/cmb2-field-order"
+  ],
   "lifecycleScripts": {
     "afterStart": "yarn env run cli wp theme activate humanity-theme"
   }


### PR DESCRIPTION
Follow-up to https://github.com/amnestywebsite/humanity-theme/pull/342 and https://github.com/amnestywebsite/humanity-theme/pull/348

**Steps to test**:
1. Start (or restart) the dev environment using `yarn env start`
1. Visit `/wp-admin/plugins.php` and see that the [required CMB extension plugins](https://github.com/amnestywebsite/humanity-theme?tab=readme-ov-file#required-plugins) are present and activated

**Considerations**:

n/a
