### PR TITLE
Move custom block variations styles to theme.json

### DIFF
--- a/private/src/styles/blocks/button/styles/_dark.scss
+++ b/private/src/styles/blocks/button/styles/_dark.scss
@@ -2,14 +2,14 @@
 .wp-block-button.is-style-dark .wp-block-button__link,
 .btn--dark,
 .btn.is-style-dark {
-  border: 1px solid $color-black;
-  background: $color-black;
-  color: $color-white;
+  // border: 1px solid $color-black;
+  // background: $color-black;
+  // color: $color-white;
 
-  &:hover,
-  &:focus {
-    background-color: $color-white;
-    border-color: $color-black;
-    color: $color-black;
-  }
+  // &:hover,
+  // &:focus {
+  //   background-color: $color-white;
+  //   border-color: $color-black;
+  //   color: $color-black;
+  // }
 }

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -255,6 +255,31 @@
         "bottom": "0px",
         "left": "2rem"
       }
+    },
+    "blocks": {
+      "core/button": {
+        "variations": {
+          "dark": {
+            "color": {
+              "background": "black",
+              "text": "white"
+            },
+            "border": {
+              "color": "black",
+              "width": "1px"
+            },
+            ":hover": {
+              "color": {
+                "background": "white",
+                "text": "black"
+              },
+              "border": {
+                "color": "black"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "templateParts": [


### PR DESCRIPTION
This is an example PR to move SCSS styles to theme.json for custom block variations.

This is working fine in the editor, but failing in the actual site.
It might be due to an issue with Gutenberg/WordPress itself.