### PR TITLE
Replace static font sizes with CSS vars from theme.json

### DIFF
--- a/private/package.json
+++ b/private/package.json
@@ -46,7 +46,6 @@
     "file-loader": "^6.2.0",
     "mini-css-extract-plugin": "^2.4.5",
     "node-normalize-scss": "^8.1.2",
-    "normalize.css": "^8.0.1",
     "postcss": "^8.4.32",
     "postcss-banner": "^4.0.1",
     "postcss-loader": "^7.0.1",

--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -9,9 +9,6 @@
 // @see https://github.com/sass-mq/sass-mq
 @import "sass-mq";
 
-// Normalize, from npm
-@import "~normalize.css/normalize";
-
 // Flickity slider, from npm
 @import "~flickity/dist/flickity.css";
 

--- a/private/src/styles/base/_base.scss
+++ b/private/src/styles/base/_base.scss
@@ -39,6 +39,7 @@ body {
   -webkit-font-smoothing: antialiased; /* 3 */
   overflow-x: hidden;
   min-height: 100vh;
+  margin: 0;
   display: flex;
   flex-direction: column;
 }
@@ -58,6 +59,7 @@ body.rtl {
 main {
   position: relative;
   flex: 1 0 auto;
+  display: block;
 }
 
 .ie .main {

--- a/private/src/styles/base/_images-editor.scss
+++ b/private/src/styles/base/_images-editor.scss
@@ -13,7 +13,7 @@
   justify-content: space-between;
   align-items: flex-end;
   width: 100%;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   background-color: rgba($color-black, .55);
   color: $color-white;
   word-break: keep-all;

--- a/private/src/styles/base/_images.scss
+++ b/private/src/styles/base/_images.scss
@@ -56,7 +56,7 @@ figure {
   justify-content: space-between;
   align-items: flex-end;
   width: 100%;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   background-color: rgba($color-black, .55);
   color: $color-white;
   word-break: keep-all;

--- a/private/src/styles/base/_reset.scss
+++ b/private/src/styles/base/_reset.scss
@@ -1,5 +1,13 @@
 /**
- * As well as using normalize.css, it is often advantageous to
+ * Whilst most of the rules in here have been adapted from
+ * normalize.css, it is not just a copy/paste job.
+ * Some rules have been adjusted, some have been removed
+ * completely, etc.
+ * Props to https://necolas.github.io/normalize.css/
+ */
+
+/**
+ * It is often advantageous to
  * remove all margins from certain elements.
  */
 body,
@@ -11,4 +19,208 @@ table, th, td, caption,
 hr {
   margin: 0;
   padding: 0;
+}
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+pre {
+  // stylelint-disable-next-line font-family-no-duplicate-names
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  // stylelint-disable-next-line declaration-block-no-duplicate-properties
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+code,
+kbd,
+samp {
+  // stylelint-disable-next-line font-family-no-duplicate-names
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+legend {
+  box-sizing: border-box; /* 1 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 2 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+summary {
+  display: list-item;
 }

--- a/private/src/styles/blocks/action-block/_main.scss
+++ b/private/src/styles/blocks/action-block/_main.scss
@@ -53,13 +53,13 @@
   padding: 8px;
   background-color: $color-black;
   color: $color-white;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   text-transform: uppercase;
 }
 
 .actionBlock-content {
   padding: 16px;
-  font-size: 24px;
+  font-size: var(--wp--preset--font-size--heading-5);
 }
 
 .actionBlock-content p {

--- a/private/src/styles/blocks/button/_sizes.scss
+++ b/private/src/styles/blocks/button/_sizes.scss
@@ -5,7 +5,7 @@
 }
 
 .btn--large {
-  font-size: 30px;
+  font-size: var(--wp--preset--font-size--heading-6) !important;
   padding: 11px 20px;
   line-height: 1;
 }

--- a/private/src/styles/blocks/button/styles/_default.scss
+++ b/private/src/styles/blocks/button/styles/_default.scss
@@ -12,7 +12,7 @@
   border-radius: $base-border-radius;
   font-family: var(--wp--preset--font-family--secondary);
   font-weight: bold;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   text-transform: uppercase;
 
   &:hover,

--- a/private/src/styles/blocks/call-to-action/_base.scss
+++ b/private/src/styles/blocks/call-to-action/_base.scss
@@ -23,24 +23,19 @@
 }
 
 .callToAction-preHeading {
-  font-size: 21px;
+  font-size: var(--wp--preset--font-size--heading-4);
   text-align: center;
 
   @include mq(small) {
-    font-size: 31px;
     margin-bottom: 20px;
   }
 }
 
 .callToAction-heading {
-  font-size: 30px;
+  font-size: var(--wp--preset--font-size--heading-2);
   margin-bottom: 20px;
   text-transform: uppercase;
   text-align: center;
-
-  @include mq(small) {
-    font-size: 41px;
-  }
 }
 
 .callToAction-content {

--- a/private/src/styles/blocks/call-to-action/_sizes.scss
+++ b/private/src/styles/blocks/call-to-action/_sizes.scss
@@ -5,18 +5,18 @@
 
 .article-sidebar .callToAction .callToAction-preHeading,
 .callToAction--small .callToAction-preHeading {
-  font-size: 21px;
+  font-size: var(--wp--preset--font-size--heading-4);
   margin-bottom: 20px;
 }
 
 .article-sidebar .callToAction .callToAction-heading,
 .callToAction--small .callToAction-heading {
-  font-size: 30px;
+  font-size: var(--wp--preset--font-size--heading-3);
   margin-bottom: 20px;
 }
 
 .article-sidebar .callToAction .callToAction-content,
 .callToAction--small .callToAction-content {
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   margin-bottom: 20px;
 }

--- a/private/src/styles/blocks/core-blocks/_blockquote.scss
+++ b/private/src/styles/blocks/core-blocks/_blockquote.scss
@@ -106,55 +106,27 @@ blockquote p,
   position: relative;
   margin-bottom: 20px;
   font-weight: bold;
-  font-size: 24px !important;
+  font-size: var(--wp--preset--font-size--heading-3) !important;
   line-height: 1.2 !important;
 
   &:last-of-type {
     margin-bottom: 0;
   }
-
-  @include mq(x-small) {
-    font-size: 32px !important;
-  }
-
-  @include mq(medium) {
-    font-size: 36px !important;
-  }
 }
 
 .blockquote.is-medium p {
-  font-size: 20px !important;
-
-  @include mq(x-small) {
-    font-size: 28px !important;
-  }
-
-  @include mq(medium) {
-    font-size: 32px !important;
-  }
+  font-size: var(--wp--preset--font-size--heading-4) !important;
 }
 
 .blockquote.is-small p {
-  font-size: 16px !important;
+  font-size: var(--wp--preset--font-size--heading-5) !important;
   line-height: 1.2 !important;
-
-  @include mq(x-small) {
-    font-size: 24px !important;
-  }
-
-  @include mq(medium) {
-    font-size: 28px !important;
-  }
 }
 
 .blockquote[class*="align-"] p:first-of-type::before,
 .blockquote[class*="align-"] p:last-of-type::after {
   display: inline-block;
-  font-size: 24px;
-
-  @include mq(small) {
-    font-size: 32px;
-  }
+  font-size: var(--wp--preset--font-size--heading-3);
 }
 
 .blockquote[class*="align-"] p:first-of-type::before {
@@ -193,18 +165,10 @@ blockquote cite,
 .blockquote cite {
   display: inline-block;
   font-style: normal;
-  font-size: 18px !important;
+  font-size: var(--wp--preset--font-size--heading-5) !important;
   font-weight: bold !important;
   line-height: 40px !important;
   padding-bottom: 24px;
-
-  @include mq(x-small) {
-    font-size: 20px !important;
-  }
-
-  @include mq(medium) {
-    font-size: 24px !important;
-  }
 }
 
 .blockquote.is-lined:not([class*="align"]) cite::after {
@@ -221,28 +185,14 @@ blockquote cite,
 }
 
 .blockquote.is-medium cite {
-  font-size: 16px !important;
-
-  @include mq(x-small) {
-    font-size: 20px !important;
-  }
-
-  @include mq(medium) {
-    font-size: 22px !important;
-  }
+  font-size: var(--wp--preset--font-size--heading-6) !important;
 }
 
 .blockquote.is-small cite {
-  font-size: 14px !important;
+  font-size: var(--wp--preset--font-size--small) !important;
   line-height: 40px !important;
 
-  @include mq(x-small) {
-    font-size: 18px !important;
-  }
-
   @include mq(medium) {
-    font-size: 20px !important;
-
     &::after {
       height: 6px;
     }
@@ -286,11 +236,7 @@ blockquote cite,
 .blockquote[class*="align-"].is-small p:first-of-type::before,
 .blockquote[class*="align-"].is-small p:last-of-type::after {
   display: inline-block;
-  font-size: 16px;
-
-  @include mq(small) {
-    font-size: 28px;
-  }
+  font-size: var(--wp--preset--font-size--heading-5);
 }
 
 .section > .container .blockquote,

--- a/private/src/styles/blocks/core-blocks/_image.scss
+++ b/private/src/styles/blocks/core-blocks/_image.scss
@@ -16,7 +16,7 @@
 
 .wp-block-image figcaption {
   color: $color-grey-dark;
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--small);
   text-align: left;
 
   .rtl & {

--- a/private/src/styles/blocks/core-blocks/_latest-posts.scss
+++ b/private/src/styles/blocks/core-blocks/_latest-posts.scss
@@ -32,7 +32,7 @@
   color: $color-black;
   text-decoration: none;
   line-height: 1.1;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   font-family: var(--wp--preset--font-family--secondary);
   padding: 8px;
   width: 100%;

--- a/private/src/styles/blocks/core-blocks/_rss.scss
+++ b/private/src/styles/blocks/core-blocks/_rss.scss
@@ -26,14 +26,14 @@
   margin-bottom: 10px;
   order: 1;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--small);
   color: $color-black;
 }
 
 .wp-block-rss__item-excerpt {
   order: 3;
   margin-top: 6px;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   line-height: 1;
   text-align: justify;
   color: $color-black;
@@ -41,7 +41,7 @@
 
 .wp-block-rss__item-author {
   order: 4;
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--small);
   line-height: 17px;
   color: $color-grey-md-light;
   padding-top: 16px;

--- a/private/src/styles/blocks/core-blocks/_separator.scss
+++ b/private/src/styles/blocks/core-blocks/_separator.scss
@@ -22,7 +22,7 @@
   content: "\00b7 \00b7 \00b7";
   padding-left: 2em;
   color: $color-black-light;
-  font-size: 20px;
+  font-size: var(--wp--preset--font-size--regular);
   font-family: serif;
   letter-spacing: 2em;
 }

--- a/private/src/styles/blocks/custom-card/_main.scss
+++ b/private/src/styles/blocks/custom-card/_main.scss
@@ -47,7 +47,7 @@
   padding: 8px;
   background-color: $color-grey-x-light;
   color: $color-black-mid-dark;
-  font-size: 24px;
+  font-size: var(--wp--preset--font-size--large);
   text-transform: uppercase;
 }
 
@@ -56,7 +56,7 @@
   font-weight: normal;
   font-family: var(--wp--preset--font-family--primary);
   padding: 10px;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   background-color: $color-grey-x-light;
   color: $color-black-mid-dark;
   margin-top: auto;

--- a/private/src/styles/blocks/header/_main.scss
+++ b/private/src/styles/blocks/header/_main.scss
@@ -191,7 +191,7 @@
   text-decoration: none;
   font-family: var(--wp--preset--font-family--secondary);
   padding: 5px;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   color: $color-white;
   background-color: $color-black;
 }

--- a/private/src/styles/blocks/hero/_main.scss
+++ b/private/src/styles/blocks/hero/_main.scss
@@ -34,7 +34,7 @@
   display: table;
   padding: 10px 16px;
   max-width: 460px;
-  font-size: 1.5rem;
+  font-size: var(--wp--preset--font-size--large);
 
   @include mq(xx-small) {
     padding: 10px 20px;
@@ -45,7 +45,7 @@
 .hero-title span {
   margin: 0;
   padding: 0 16px;
-  font-size: 4.5rem;
+  font-size: var(--wp--preset--font-size--heading-1);
   line-height: 1.3 !important;
   background-color: rgba(0, 0, 0, 0.45);
   color: #fff;
@@ -54,12 +54,7 @@
   box-decoration-break: clone;
 
   @include mq(xx-small) {
-    font-size: 48px;
     padding: 0 20px;
-  }
-
-  @include mq(small) {
-    font-size: 72px;
   }
 }
 

--- a/private/src/styles/blocks/image-block/_editor.scss
+++ b/private/src/styles/blocks/image-block/_editor.scss
@@ -74,7 +74,7 @@
   border-radius: 0 !important;
   font-family: var(--wp--preset--font-family--secondary);
   font-weight: bold;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   text-transform: uppercase;
 
   @include placeholder {
@@ -93,7 +93,7 @@
   padding: 5px 10px 5px 5px !important;
   width: auto !important;
   color: $color-white !important;
-  font-size: 14px !important;
+  font-size: var(--wp--preset--font-size--x-small) !important;
 }
 
 .imageBlock-title,

--- a/private/src/styles/blocks/image-block/_main.scss
+++ b/private/src/styles/blocks/image-block/_main.scss
@@ -114,13 +114,13 @@
 
 .imageBlock-title {
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 41px;
+  font-size: var(--wp--preset--font-size--huge);
   font-weight: bold;
 }
 
 .imageBlock-content {
   font-family: var(--wp--preset--font-family--primary);
-  font-size: 21px;
+  font-size: var(--wp--preset--font-size--regular);
 
   > p:last-child {
     margin-bottom: 0;
@@ -133,7 +133,7 @@
 
 .imageBlock-caption {
   margin-top: 7px !important;
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--x-small);
   font-family: var(--wp--preset--font-family--primary);
   line-height: 1.4;
   color: $color-grey-base;

--- a/private/src/styles/blocks/linklist/_main.scss
+++ b/private/src/styles/blocks/linklist/_main.scss
@@ -25,7 +25,7 @@
   margin-bottom: 12px;
   margin-top: 12px;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 19px;
+  font-size: var(--wp--preset--font-size--regular);
   font-weight: normal;
   line-height: 1.2;
 }
@@ -51,7 +51,7 @@
   display: inline-block;
   padding: 4px 8px;
   text-transform: uppercase;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--regular);
   font-family: var(--wp--preset--font-family--secondary);
   font-weight: bold;
   background-color: $color-black;

--- a/private/src/styles/blocks/links-with-icons/_editor.scss
+++ b/private/src/styles/blocks/links-with-icons/_editor.scss
@@ -123,7 +123,7 @@
 }
 
 .linksWithIcons-group .linksWithIcons-bigtext [data-rich-text-placeholder] {
-  font-size: 48px;
+  font-size: var(--wp--preset--font-size--huge);
 }
 
 .linksWithIcons-group.is-style-square .linksWithIcons {

--- a/private/src/styles/blocks/links-with-icons/_elements.scss
+++ b/private/src/styles/blocks/links-with-icons/_elements.scss
@@ -32,13 +32,9 @@
 }
 
 .linksWithIcons-title {
-  font-size: 26px;
+  font-size: var(--wp--preset--font-size--heading-3);
   font-weight: bold;
   line-height: 1;
-
-  @include mq(x-small) {
-    font-size: 31px;
-  }
 
   .is-style-square & {
     font-size: var(--wp--preset--font-size--heading-6);

--- a/private/src/styles/blocks/petition-list/_main.scss
+++ b/private/src/styles/blocks/petition-list/_main.scss
@@ -64,7 +64,7 @@
   font-family: var(--wp--preset--font-family--secondary);
   color: $color-black;
   font-weight: bold;
-  font-size: 28px;
+  font-size: var(--wp--preset--font-size--heading-4);
 }
 
 .petition-item .petition-itemExcerpt {

--- a/private/src/styles/blocks/postlist/_header.scss
+++ b/private/src/styles/blocks/postlist/_header.scss
@@ -10,7 +10,7 @@
   margin-bottom: 0;
   width: 100%;
   float: none;
-  font-size: 28px;
+  font-size: var(--wp--preset--font-size--heading-4);
   line-height: 1.2;
 
   @include mq(xm-small) {
@@ -23,7 +23,7 @@
   margin-top: 12px;
   margin-bottom: 8px;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--x-small);
   font-weight: bold;
   text-align: left;
   letter-spacing: .3px;

--- a/private/src/styles/blocks/postlist/_pagination.scss
+++ b/private/src/styles/blocks/postlist/_pagination.scss
@@ -5,7 +5,7 @@
   flex-wrap: wrap;
   margin: 0 auto;
   width: 100%;
-  font-size: 24px;
+  font-size: var(--wp--preset--font-size--heading-5);
   font-family: var(--wp--preset--font-family--secondary);
   font-weight: bold;
   line-height: 1.25;

--- a/private/src/styles/blocks/postlist/_post-search.scss
+++ b/private/src/styles/blocks/postlist/_post-search.scss
@@ -18,7 +18,7 @@
 .post--result .post-title {
   margin-bottom: 15px;
   padding: 0;
-  font-size: 31px;
+  font-size: var(--wp--preset--font-size--heading-4);
   line-height: 1.2;
 }
 
@@ -28,11 +28,11 @@
 
 .post--result .post-excerpt {
   margin-bottom: 15px;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
 }
 
 .post--result .post-byline {
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
 }
 
 .post--result .post-category,
@@ -57,7 +57,7 @@
 .post--result .post-topic {
   font-family: var(--wp--preset--font-family--secondary);
   text-transform: uppercase;
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--small);
 
 }
 
@@ -65,7 +65,7 @@
   font-family: var(--wp--preset--font-family--secondary);
   text-transform: uppercase;
   margin-right: 16px;
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--small);
 }
 
 .post--result .post-title a::before {

--- a/private/src/styles/blocks/postlist/_post.scss
+++ b/private/src/styles/blocks/postlist/_post.scss
@@ -150,7 +150,7 @@
   color: $color-white;
   font-family: var(--wp--preset--font-family--secondary);
   font-weight: bold;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   text-transform: uppercase;
   background-color: $color-black;
 }
@@ -160,7 +160,7 @@
   padding: 8px 8px 0;
   font-family: var(--wp--preset--font-family--secondary);
   font-weight: bold;
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--x-small);
   color: $color-grey-mid-dark;
   background-color: $color-white;
 }
@@ -168,7 +168,7 @@
 .post-title {
   padding: 0 8px;
   margin-bottom: 0;
-  font-size: 28px;
+  font-size: var(--wp--preset--font-size--heading-5);
 }
 
 .post-title a {

--- a/private/src/styles/blocks/slider/_main.scss
+++ b/private/src/styles/blocks/slider/_main.scss
@@ -15,7 +15,7 @@
   text-align: center;
   min-height: 56px;
   background-color: $color-grey-light;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   text-transform: uppercase;
   font-family: var(--wp--preset--font-family--secondary);
   flex: 1 1 auto;
@@ -420,29 +420,21 @@
 }
 
 h1.slide-title {
-  font-size: 43px;
+  font-size: var(--wp--preset--font-size--heading-2);
   text-transform: uppercase;
   color: $color-white !important;
 
   .rtl & {
     text-align: right;
   }
-
-  @include mq(small) {
-    font-size: 48px;
-  }
 }
 
 h2.slide-subtitle {
-  font-size: 30px;
+  font-size: var(--wp--preset--font-size--heading-3);
   color: $color-white !important;
 
   .rtl & {
     text-align: right;
-  }
-
-  @include mq(small) {
-    font-size: 36px;
   }
 }
 
@@ -455,14 +447,10 @@ h2.slide-subtitle {
 }
 
 .slide-content p {
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--regular);
 
   &:last-child {
     margin-bottom: 0;
-  }
-
-  @include mq(small) {
-    font-size: 18px;
   }
 }
 
@@ -502,10 +490,10 @@ h2.slide-subtitle {
   z-index: 1;
   font-family: var(--wp--preset--font-family--secondary);
   text-transform: uppercase;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
 
   @include mq(small) {
-    font-size: 34px;
+    font-size: var(--wp--preset--font-size--large);
   }
 }
 

--- a/private/src/styles/blocks/sutori-embed/_main.scss
+++ b/private/src/styles/blocks/sutori-embed/_main.scss
@@ -2,7 +2,7 @@
   margin-top: 24px;
   text-align: center;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 36px;
+  font-size: var(--wp--preset--font-size--larger);
   text-decoration: underline;
   text-decoration-skip-ink: auto;
 }

--- a/private/src/styles/blocks/term-list/_main.scss
+++ b/private/src/styles/blocks/term-list/_main.scss
@@ -19,7 +19,7 @@
   height: 75px;
   background-color: $color-grey-x-light;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 28px;
+  font-size: var(--wp--preset--font-size--heading-4);
   font-weight: bold;
   color: $color-black;
 

--- a/private/src/styles/blocks/tweet-action/_editor.scss
+++ b/private/src/styles/blocks/tweet-action/_editor.scss
@@ -8,7 +8,7 @@
   max-width: calc(100% - 54px);
   background: transparent;
   font-family: var(--wp--preset--font-family--secondary) !important;
-  font-size: 28px !important;
+  font-size: var(--wp--preset--font-size--heading-4) !important;
   font-weight: bold;
   line-height: 1.4 !important;
   text-transform: uppercase;
@@ -19,7 +19,7 @@
   margin-bottom: 16px !important;
   padding: 10px !important;
   font-family: var(--wp--preset--font-family--primary) !important;
-  font-size: 21px !important;
+  font-size: var(--wp--preset--font-size--heading-6) !important;
 }
 
 .tweetAction-button {

--- a/private/src/styles/blocks/tweet-action/_tweet.scss
+++ b/private/src/styles/blocks/tweet-action/_tweet.scss
@@ -56,7 +56,7 @@
   overflow-y: auto;
   background-color: $color-white;
   font-family: var(--wp--preset--font-family--primary);
-  font-size: 21px;
+  font-size: var(--wp--preset--font-size--heading-6);
 
   @include mq(small) {
     max-height: none;
@@ -100,7 +100,7 @@
   min-height: unset;
   max-height: unset;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 24px;
+  font-size: var(--wp--preset--font-size--heading-5);
   text-align: center;
 }
 
@@ -113,7 +113,7 @@
   line-height: normal;
   color: $color-black;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
 }
 
 .is-style-alternative-style .tweetButton {

--- a/private/src/styles/components/form/_checkbox-group.scss
+++ b/private/src/styles/components/form/_checkbox-group.scss
@@ -1,6 +1,6 @@
 .checkboxGroup {
   position: relative;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
 }
 
 .checkboxGroup-button {

--- a/private/src/styles/components/form/_input.scss
+++ b/private/src/styles/components/form/_input.scss
@@ -4,7 +4,7 @@ optgroup,
 select,
 textarea {
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
 }
 
 textarea {
@@ -54,7 +54,7 @@ input,
 textarea {
   @include placeholder {
     font-family: var(--wp--preset--font-family--secondary);
-    font-size: 16px;
+    font-size: var(--wp--preset--font-size--small);
     font-weight: normal;
     text-transform: uppercase;
     color: $color-grey-base;
@@ -67,7 +67,7 @@ textarea,
 .woocommerce-cart table.cart td.actions .coupon .input-text {
   padding: 12px;
   width: 100%;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   font-family: var(--wp--preset--font-family--secondary);
   appearance: none;
   text-transform: uppercase;

--- a/private/src/styles/components/form/_select2.scss
+++ b/private/src/styles/components/form/_select2.scss
@@ -4,7 +4,7 @@
   padding: 12px;
   height: auto !important;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   font-weight: normal;
   line-height: normal;
   text-transform: uppercase;
@@ -31,7 +31,7 @@
 
 .element-select .select2-results__option {
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--x-small);
   font-weight: normal;
   text-transform: uppercase;
   color: $color-grey-base;

--- a/private/src/styles/components/grid/_editor.scss
+++ b/private/src/styles/components/grid/_editor.scss
@@ -105,7 +105,7 @@
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
     border-radius: 0;
     padding: 8px;
-    font-size: 18px;
+    font-size: var(--wp--preset--font-size--regular);
     border: none;
     box-shadow: none;
     max-height: none;
@@ -152,11 +152,11 @@
     margin: 0;
     line-height: 1;
     margin-bottom: 4px;
-    font-size: 18px;
+    font-size: var(--wp--preset--font-size--regular);
   }
 
   .post-meta {
-    font-size: 14px;
+    font-size: var(--wp--preset--font-size--x-small);
     font-style: oblique;
     color: rgb(85, 93, 102);
   }
@@ -207,7 +207,7 @@
     background-color: $color-blue-xx-light;
     width: 100%;
     padding: 12px 18px;
-    font-size: 14px;
+    font-size: var(--wp--preset--font-size--x-small);
     font-weight: bold;
     border: none;
     color: $color-white;

--- a/private/src/styles/components/grid/_item.scss
+++ b/private/src/styles/components/grid/_item.scss
@@ -33,7 +33,7 @@
   padding: 12px;
   color: $color-black;
   line-height: 1.4;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   background-color: $color-white;
   max-width: 100%;
 }
@@ -48,7 +48,7 @@
 .grid-itemMeta {
   display: block;
   text-transform: uppercase;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   font-family: var(--wp--preset--font-family--secondary);
   font-weight: bold;
   max-width: 100%;
@@ -66,6 +66,11 @@
   width: max-content;
   background-color: $color-black;
   color: $color-white;
+  text-decoration: none;
+}
+
+// increased specificity to override global link decoration
+.single main .grid-itemMeta a {
   text-decoration: none;
 }
 

--- a/private/src/styles/layout/_language-banner.scss
+++ b/private/src/styles/layout/_language-banner.scss
@@ -48,7 +48,7 @@
   padding: 8px 20px;
   color: $color-white;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   font-weight: bold;
   text-transform: uppercase;
 }
@@ -68,7 +68,7 @@ button.language-selectorClose {
   align-items: center;
   margin-left: 24px;
   padding: 11px;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   order: 0;
 
   @include mq(xx-small) {

--- a/private/src/styles/layout/_page-hero-editor.scss
+++ b/private/src/styles/layout/_page-hero-editor.scss
@@ -20,7 +20,7 @@
 .page-heroTitle {
   margin: 0;
   padding: 0 20px;
-  font-size: 72px;
+  font-size: var(--wp--preset--font-size--heading-1);
   line-height: 1.3 !important;
   background-color: rgba($color-black, .45);
   color: $color-white;
@@ -32,7 +32,7 @@ p.page-heroContent {
   padding: 10px 20px;
   max-width: 460px;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 24px;
+  font-size: var(--wp--preset--font-size--heading-5);
   background-color: rgba($color-black, .45);
   color: $color-white;
   margin-top: 0;

--- a/private/src/styles/layout/_page-hero.scss
+++ b/private/src/styles/layout/_page-hero.scss
@@ -33,17 +33,12 @@
   max-width: 840px;
   margin: 0;
   padding: 0 16px;
-  font-size: 36px;
+  font-size: var(--wp--preset--font-size--heading-1);
   line-height: 1.2;
   text-transform: uppercase;
 
   @include mq(xx-small) {
-    font-size: 48px;
     padding: 0 20px;
-  }
-
-  @include mq(small) {
-    font-size: 72px;
   }
 }
 
@@ -59,7 +54,7 @@ p.page-heroContent {
   margin-bottom: 0;
   padding: 10px 16px;
   max-width: 460px;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   background-color: rgba($color-black, .45);
 
   @include mq(xx-small) {
@@ -78,7 +73,7 @@ p.page-heroContent {
   padding: 16px;
 
   .btn {
-    font-size: 24px;
+    font-size: var(--wp--preset--font-size--heading-5);
     padding: 10px 14px;
 
     @include mq(xx-small) {

--- a/private/src/styles/layout/footer/_editor.scss
+++ b/private/src/styles/layout/footer/_editor.scss
@@ -12,13 +12,13 @@
 }
 
 .amnesty-footer-container p {
-  font-size: 12px;
+  font-size: var(--wp--preset--font-size--x-small);
 }
 
 .amnesty-footer-container h4 {
   margin-bottom: 24px;
   padding-bottom: 12px;
-  font-size: 20px;
+  font-size: var(--wp--preset--font-size--heading-6);
   text-transform: uppercase;
   color: var(--wp--preset--color--amnesty-grey-md-light);
   font-family: var(--font-family-secondary);
@@ -27,7 +27,7 @@
 }
 
 .amnesty-footer-container h2 {
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   color: var(--wp--preset--color--white);
   text-transform: uppercase;
   margin-bottom: 0;
@@ -43,12 +43,12 @@
 
 .amnesty-footer-container a {
   color: var(--wp--preset--color--white);
-  font-size: 12px !important;
+  font-size: var(--wp--preset--font-size--x-small) !important;
 }
 
 .amnesty-footer-container .amnesty-policy-links {
   display: flex;
-  font-size: 12px;
+  font-size: var(--wp--preset--font-size--x-small);
 }
 
 .amnesty-footer-container .amnesty-policy-links li {

--- a/private/src/styles/layout/footer/styles/_classic.scss
+++ b/private/src/styles/layout/footer/styles/_classic.scss
@@ -7,7 +7,7 @@
 .page-footer a {
   display: inline-block;
   color: $color-white;
-  font-size: 12px;
+  font-size: var(--wp--preset--font-size--x-small);
   font-family: sans-serif;
 
   &.btn--white {
@@ -24,7 +24,7 @@
 .page-footerSections > li > a:first-of-type {
   margin-bottom: 24px;
   padding-bottom: 12px;
-  font-size: 21px;
+  font-size: var(--wp--preset--font-size--heading-6);
   text-transform: uppercase;
   color: $color-grey-md-light;
   font-family: var(--wp--preset--font-family--secondary);
@@ -104,7 +104,7 @@
 }
 
 .page-footerSection p {
-  font-size: 12px;
+  font-size: var(--wp--preset--font-size--x-small);
   line-height: 1.5;
 
   &:not(:last-child) {
@@ -146,7 +146,7 @@
   padding: 4px 8px;
   color: $color-white;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   font-weight: bold;
   text-transform: uppercase;
 }
@@ -196,7 +196,7 @@
   margin: 0;
   padding: 0;
   list-style: none;
-  font-size: 12px;
+  font-size: var(--wp--preset--font-size--x-small);
   line-height: 1.5;
   font-family: sans-serif;
 }
@@ -228,7 +228,7 @@
 }
 
 .page-footerCopyright {
-  font-size: 12px;
+  font-size: var(--wp--preset--font-size--x-small);
   line-height: 1.5;
   color: rgba($color-white, .7);
   padding-top: 8px;
@@ -249,7 +249,7 @@
 }
 
 .page-footerBottomTitle {
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   text-transform: uppercase;
   color: $color-white;
   margin-bottom: 12px;

--- a/private/src/styles/layout/footer/styles/_fse.scss
+++ b/private/src/styles/layout/footer/styles/_fse.scss
@@ -6,13 +6,13 @@
 }
 
 .amnesty-footer-template-part p {
-  font-size: 12px;
+  font-size: var(--wp--preset--font-size--x-small);
 }
 
 .amnesty-footer-template-part h4 {
   margin-bottom: 24px;
   padding-bottom: 12px;
-  font-size: 20px;
+  font-size: var(--wp--preset--font-size--heading-6);
   text-transform: uppercase;
   color: var(--wp--preset--color--amnesty-grey-md-light);
   font-family: var(--font-family-secondary);
@@ -21,7 +21,7 @@
 }
 
 .amnesty-footer-template-part h2 {
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
   color: var(--wp--preset--color--white);
   text-transform: uppercase;
   margin-bottom: 0;
@@ -36,13 +36,13 @@
 
 .amnesty-footer-template-part a {
   color: var(--wp--preset--color--white);
-  font-size: 12px;
+  font-size: var(--wp--preset--font-size--x-small);
   font-family: sans-serif;
 }
 
 .amnesty-footer-template-part .amnesty-policy-links {
   display: flex;
-  font-size: 12px;
+  font-size: var(--wp--preset--font-size--x-small);
 }
 
 .amnesty-footer-template-part .amnesty-policy-links li {

--- a/private/src/styles/layout/header/shared/_base.scss
+++ b/private/src/styles/layout/header/shared/_base.scss
@@ -3,7 +3,7 @@
   top: -100%;
   z-index: 11;
   height: 60px;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   color: $color-black;
   transition: top .5s ease-in-out;
   font-family: var(--wp--preset--font-family--secondary);

--- a/private/src/styles/layout/navigation/shared/_mobile.scss
+++ b/private/src/styles/layout/navigation/shared/_mobile.scss
@@ -13,7 +13,7 @@
   transition: transform .2s ease-in-out;
   transform: translate3d(100%, 0, 0);
   background-color: $color-white;
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
 
   @include mq(small) {
     top: 72px; // header height on larger screens

--- a/private/src/styles/pages/_author.scss
+++ b/private/src/styles/pages/_author.scss
@@ -143,13 +143,12 @@
 .author-banner-caption {
   background-color: rgba($color-black, .1);
   padding: 5px;
-  font-size: 15px;
+  font-size: var(--wp--preset--font-size--small);
   font-style: italic;
   color: $color-white;
   text-align: center;
 
   @include mq(large) {
-    font-size: 10px;
     font-style: unset;
     text-align: unset;
   }

--- a/private/src/styles/pages/_petitions.scss
+++ b/private/src/styles/pages/_petitions.scss
@@ -1,10 +1,10 @@
 .page-template-page-petitions .petition-index-title {
-  font-size: 28px;
+  font-size: var(--wp--preset--font-size--heading-4);
   margin-bottom: 24px;
 }
 
 .page-template-page-petitions .petition-index-btn {
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   position: absolute;
   bottom: 12px;
   width: calc(100% - 30px);
@@ -12,7 +12,7 @@
 
 .page-template-page-petitions .petition-index-excerpt p {
   text-transform: uppercase;
-  font-size: 18px;
+  font-size: var(--wp--preset--font-size--regular);
 }
 
 .page-template-page-petitions .petition-index-excerpt {

--- a/private/src/styles/pages/_single.scss
+++ b/private/src/styles/pages/_single.scss
@@ -31,7 +31,7 @@
   padding: 10px;
   transition: background-color .25s;
   font-family: var(--wp--preset--font-family--secondary);
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--x-small);
 }
 
 .topics-container li a:hover,

--- a/private/src/styles/pages/article/_back-link.scss
+++ b/private/src/styles/pages/article/_back-link.scss
@@ -1,7 +1,7 @@
 .article-backLink {
   display: inline-flex;
   text-decoration: underline;
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--x-small);
   align-items: center;
   margin-bottom: 30px;
 }

--- a/private/src/styles/pages/article/_byline.scss
+++ b/private/src/styles/pages/article/_byline.scss
@@ -4,7 +4,7 @@
 
 .authorInfoContainer {
   align-self: center;
-  font-size: 1rem;
+  font-size: var(--wp--preset--font-size--regular);
   text-decoration-skip-ink: auto;
 }
 

--- a/private/src/styles/pages/article/_header.scss
+++ b/private/src/styles/pages/article/_header.scss
@@ -20,7 +20,7 @@
 }
 
 .article-header .article-term {
-  font-size: 16px;
+  font-size: var(--wp--preset--font-size--small);
   text-transform: uppercase;
   font-family: var(--wp--preset--font-family--secondary);
 }

--- a/private/src/styles/pages/article/_meta.scss
+++ b/private/src/styles/pages/article/_meta.scss
@@ -17,7 +17,7 @@
   display: flex;
   justify-content: space-between;
   padding: 10px 0;
-  font-size: 1rem;
+  font-size: var(--wp--preset--font-size--regular);
 }
 
 .article-metaDataRow > *:not(:last-child)::after {

--- a/private/src/styles/pages/search/results/_active-filters.scss
+++ b/private/src/styles/pages/search/results/_active-filters.scss
@@ -28,7 +28,7 @@
   margin-right: var(--wp--preset--spacing--half);
   padding: var(--wp--preset--spacing--quarter);
   background-color: $color-grey-xx-light;
-  font-size: 14px;
+  font-size: var(--wp--preset--font-size--x-small);
 
   &::after {
     content: "x";

--- a/private/yarn.lock
+++ b/private/yarn.lock
@@ -5377,7 +5377,6 @@ __metadata:
     memize: "npm:^1.1.0"
     mini-css-extract-plugin: "npm:^2.4.5"
     node-normalize-scss: "npm:^8.1.2"
-    normalize.css: "npm:^8.0.1"
     object-fit-images: "npm:^3.2.4"
     postcss: "npm:^8.4.32"
     postcss-banner: "npm:^4.0.1"

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -176,7 +176,7 @@
           "name": "Quad"
         }
       ]
-		},
+    },
     "typography": {
       "fontFamilies": [
         {
@@ -389,32 +389,32 @@
       },
       "h1": {
         "typography": {
-        "fontSize": "var(--wp--preset--font-size--heading-1)"
+          "fontSize": "var(--wp--preset--font-size--heading-1)"
         }
       },
       "h2": {
         "typography": {
-        "fontSize": "var(--wp--preset--font-size--heading-2)"
+          "fontSize": "var(--wp--preset--font-size--heading-2)"
         }
       },
       "h3": {
         "typography": {
-        "fontSize": "var(--wp--preset--font-size--heading-3)"
+          "fontSize": "var(--wp--preset--font-size--heading-3)"
         }
       },
       "h4": {
         "typography": {
-        "fontSize": "var(--wp--preset--font-size--heading-4)"
+          "fontSize": "var(--wp--preset--font-size--heading-4)"
         }
       },
       "h5": {
         "typography": {
-        "fontSize": "var(--wp--preset--font-size--heading-5)"
+          "fontSize": "var(--wp--preset--font-size--heading-5)"
         }
       },
       "h6": {
         "typography": {
-        "fontSize": "var(--wp--preset--font-size--heading-6)"
+          "fontSize": "var(--wp--preset--font-size--heading-6)"
         }
       }
     },
@@ -428,15 +428,15 @@
     }
   },
   "templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+    {
+      "name": "header",
+      "title": "Header",
+      "area": "header"
+    },
+    {
+      "name": "footer",
+      "title": "Footer",
+      "area": "footer"
+    }
+  ]
 }

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -263,6 +263,12 @@
       "fontSizes": [
         {
           "fluid": false,
+          "name": "X Small",
+          "size": ".8rem",
+          "slug": "x-small"
+        },
+        {
+          "fluid": false,
           "name": "Small",
           "size": ".9rem",
           "slug": "small"


### PR DESCRIPTION
Part of https://github.com/amnestywebsite/humanity-theme/issues/337

Thanks to @mikachan's work in https://github.com/amnestywebsite/humanity-theme/pull/354, we have the opportunity to replace much of our static font size declarations with sizes defined in theme.json. 

Inevitably, some sizes don't match exactly; instead, we have increased consistency and flexibility.