### PR TITLE
Move more font CSS to theme.json

### DIFF
--- a/private/src/styles/base/_base.scss
+++ b/private/src/styles/base/_base.scss
@@ -30,8 +30,6 @@ html.lang-open {
  *    render text using sub-pixel anti-aliasing.
  */
 body {
-  font-family: var(--wp--preset--font-family--primary);
-  color: $body-color;
   // font-feature-settings: "kern", "liga", "pnum"; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
   -ms-text-size-adjust: 100%; /* 2 */

--- a/private/src/styles/base/_links.scss
+++ b/private/src/styles/base/_links.scss
@@ -1,7 +1,5 @@
 a {
-  color: $color-black;
   transition: color .3s ease-in-out;
-  text-decoration: none;
   text-decoration-skip-ink: auto;
 }
 

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -382,6 +382,14 @@
       "lineHeight": "calc( 27px / 1.125 )"
     },
     "elements": {
+      "link": {
+        "color": {
+          "text": "var(--wp--preset--color--black)"
+        },
+        "typography": {
+          "textDecoration": "none"
+        }
+      },
       "heading": {
         "typography": {
           "fontFamily": "var(--wp--preset--font-family--secondary)",

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -373,7 +373,11 @@
     "useRootPaddingAwareAlignments": false
   },
   "styles": {
+    "color": {
+      "text": "var(--wp--preset--color--black)"
+    },
     "typography": {
+      "fontFamily": "var(--wp--preset--font-family--primary)",
       "fontSize": "var(--wp--preset--font-size--regular)",
       "lineHeight": "calc( 27px / 1.125 )"
     },


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/337

Small PR to move some more typography settings to theme.json.

**Steps to test**:
1. Ensure the primary font family is correctly used on the front-end and the Editor.
2. Ensure the main font colour is still the same.
3. Ensure all links outside of articles look the same (colour and text-decoration).

**Considerations**:
- Accessibility
  - Regions (semantic HTML tags, e.g. `<section>`; [landmarks](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#landmark_roles); etc.)
  - Screen reader compatibility, labels ([`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label), [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby), etc.)
  - Keyboard navigability
- Localisation
- RTL
