### PR TITLE
Remove superfluous padding from the body tag

### DIFF
--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -144,6 +144,10 @@
   --ms-ratio: 1.2;
 }
 
+:root :where(body) {
+  padding: 0;
+}
+
 .skipLink {
   @extend .btn; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
   @extend .u-hiddenVisually; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */


### PR DESCRIPTION
The padding originates from theme.json. We can't however remove it without leaving the block editor with no spacing between the side panels and the content area.
Rather than provide a worse editorial experience, we just override it on the frontend in CSS.

Ref: https://github.com/amnestywebsite/humanity-theme/issues/365

**Steps to test**:
1. view the frontend
2. there should no longer be whitespace between the footer and the margins on the horizontal axis
3. edit a post in the block editor
4. there should be whitespace between the admin menu and the blocks in the post
5. edit a template in the site editor
6. there should be whitespace between the sidebar and the blocks in the template
