### PR TITLE
Remove the skip link

### DIFF
--- a/private/src/styles/app.scss
+++ b/private/src/styles/app.scss
@@ -144,25 +144,6 @@
   --ms-ratio: 1.2;
 }
 
-.skipLink {
-  @extend .btn; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
-  @extend .u-hiddenVisually; /* stylelint-disable-line scss/at-extend-no-missing-placeholder */
-
-  &:active,
-  &:focus {
-    // 2^31 (1 higher than CC8, which uses 2^31 - 1)
-    z-index: 2147483648;
-    top: 3px;
-    left: 3px;
-    display: block;
-    padding: 10px 20px !important;
-    width: auto !important;
-    height: 50px !important;
-    clip: initial !important;
-    line-height: 30px;
-  }
-}
-
 .screen-reader-text {
   border: 0;
   clip: rect(1px, 1px, 1px, 1px);

--- a/wp-content/themes/humanity-theme/includes/theme-setup/wp-body-open.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/wp-body-open.php
@@ -14,20 +14,3 @@ if ( ! function_exists( 'amnesty_overlay' ) ) {
 }
 
 add_action( 'wp_body_open', 'amnesty_overlay', 1 );
-
-if ( ! function_exists( 'amnesty_skip_link' ) ) {
-	/**
-	 * Render skip to content link
-	 *
-	 * @return void
-	 */
-	function amnesty_skip_link(): void {
-		printf(
-			'<a class="skipLink" href="#main" tabindex="1">%s</a>',
-			/* translators: [front] Accessibility label for screen reader/keyboard users */
-			esc_html__( 'Skip to main content', 'amnesty' )
-		);
-	}
-}
-
-add_action( 'wp_body_open', 'amnesty_skip_link', 1 );


### PR DESCRIPTION
Once we move to full FSE, it is no longer required, as one is provided by WP core

Ref: https://github.com/amnestywebsite/humanity-theme/issues/345

**Steps to test**:
1. view the frontend
2. press [tab]
3. the skip link should no longer become visible

Skip link appearance, for reference:
![](http://bigbite.im/i/rvNwyv+)