### PR TITLE
Remove superfluous POMO file prefix; tweak l10n string

### DIFF
--- a/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
@@ -225,7 +225,7 @@ if ( ! function_exists( 'amnesty_localise_javascript' ) ) {
 
 		$data = [
 			/* translators: [front] */
-			'listSeparator'    => _x( ', ', 'list item separator', 'amnesty' ),
+			'listSeparator'    => _x( ',', 'list item separator', 'amnesty' ),
 			/* translators: [front] */
 			'openDoubleQuote'  => _x( '“', 'open double quote', 'amnesty' ),
 			/* translators: [front] */

--- a/wp-content/themes/humanity-theme/includes/theme-setup/text-domain.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/text-domain.php
@@ -17,47 +17,6 @@ if ( ! function_exists( 'amnesty_load_core_textdomain' ) ) {
 
 add_action( 'after_setup_theme', 'amnesty_load_core_textdomain' );
 
-if ( ! function_exists( 'amnesty_mofile_domain_prefix' ) ) {
-	/**
-	 * Add textdomain prefix to mofile path when loading textdomains
-	 *
-	 * Fn {wp_set_script_translations} requires JSON files to be prefixed
-	 * with the textdomain. Since the filename is not customisable when
-	 * generating the JSON files using WP CLI, the POMO files need to
-	 * include the textdomain as a prefix. Not doing this will cause
-	 * the script translations to fail to load, when loading from the
-	 * theme's languages directory.
-	 * However, prefixing these files with the text domain then causes
-	 * {load_theme_textdomain} to fail to find the MO files for loading
-	 * via PHP.
-	 *
-	 * Since it's easier to filter PHP MO file loading than it is to
-	 * rename the JSON files, this is the approach that we have gone for.
-	 * It seems very silly that core expects the textdomain prefix in
-	 * one place, whilst not expecting it in another place, but that
-	 * is the trade-off when bundling one's own translation files in
-	 * a theme/plugin, rather than in a core languages directory, but
-	 * for plugins/themes that aren't released via wp.org, there's
-	 * little alternative.
-	 *
-	 * @package Amnesty\ThemeSetup
-	 *
-	 * @param string $mofile the path to the mofile to load
-	 * @param string $domain the textdomain being loaded
-	 *
-	 * @return string
-	 */
-	function amnesty_mofile_domain_prefix( string $mofile, string $domain ): string {
-		if ( 'amnesty' !== $domain ) {
-			return $mofile;
-		}
-
-		return trailingslashit( dirname( $mofile ) ) . 'amnesty-' . basename( $mofile );
-	}
-}
-
-add_filter( 'load_textdomain_mofile', 'amnesty_mofile_domain_prefix', 10, 2 );
-
 if ( ! function_exists( 'register_theme_as_translatable' ) ) {
 	/**
 	 * Register this theme as a translatable package


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2227

We no longer require manual prefixing of theme POMO files during load.