### PR TITLE
Add flag to filter report terms

### DIFF
--- a/wp-content/themes/humanity-theme/includes/helpers/taxonomies.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/taxonomies.php
@@ -789,7 +789,11 @@ if ( ! function_exists( 'amnesty_taxonomy_to_option_list' ) ) {
 	 * @return array<int,string>
 	 */
 	function amnesty_taxonomy_to_option_list( WP_Taxonomy $taxonomy ): array {
-		$args = [ 'taxonomy' => $taxonomy->name ];
+		$args = [
+			'taxonomy'     => $taxonomy->name,
+			'hide_reports' => true,
+		];
+
 		$opts = [];
 
 		$terms = get_terms( $args );


### PR DESCRIPTION
This does nothing by itself in the theme.
However, in conjunction with a filter in
the Theme Companion, it allows for report
terms to be filtered out from term lists.

Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2967

**Steps to test**:
1. test in conjunction with https://github.com/amnestywebsite/wp-plugin-theme-companion/pull/59
2. visit the /countries/ page
3. the a-z should not include apparently-duplicate country names
4. the explore by region section should only list regions and subregions
5. country pages should include links to their annual report
6. clicking the link to the annual report should render the report page correctly
7. visit /latest/
8. click the countries dropdown
9. it should not list duplicate country names
10. edit a country term
11. the checkbox field to "hide" the term should no longer be present