### PR TITLE
Fix Article Meta Action Spacing for RTL

### DIFF
--- a/private/src/styles/pages/_single.scss
+++ b/private/src/styles/pages/_single.scss
@@ -10,7 +10,13 @@
   margin-bottom: spacing();
 }
 
+.article-footer .article-metaActions .article-share {
+  margin: 0;
+}
+
 .article-footer .article-metaActions {
+  display: flex;
+  justify-content: space-between;
   margin-top: spacing(half);
   margin-bottom: 0;
 }


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/327

Fixes the spacing issue on Article Meta Actions for RTL users

**Steps to test**:
1. Navigate to a post (either on /ar or you can change the ltr body class in dev tools)
2. Scroll down to just before Related Content
3. Notice the spacing between the social share and terms buttons

Example: http://bigbite.im/i/O8dm3g
