### PR TITLE
Bug - Image - Copyright field overhangs the picture

### DIFF
--- a/private/src/styles/blocks/core-blocks/_image.scss
+++ b/private/src/styles/blocks/core-blocks/_image.scss
@@ -28,3 +28,7 @@
   max-width: 100%;
   height: auto;
 }
+
+.wp-block-image > div {
+  width: fit-content;
+}


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/323

Fixes an issue with image meta data extending outside the limits of the image if image size is small

**Steps to test**:
1. Edit a post
2. Insert an image block and pick an image
3. Change the image size to something small (hero small or image block for example)
4. Save and view the frontend
5. Image meta (Caption and Credit) should be contained within image size and not extend outside of it

Example: http://bigbite.im/i/Jo4bDS