### PR TITLE
.org AR - Logo Height

### DIFF
--- a/private/src/styles/layout/header/shared/_logo.scss
+++ b/private/src/styles/layout/header/shared/_logo.scss
@@ -27,6 +27,7 @@
 .logo-logoType,
 .logo-logoMark {
   max-height: 100% !important;
+  min-height:100%
 }
 
 .logo-logoType {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2968

Adds a min-height to the site logo to remove white space above and below logo on /ar

**Steps to test**:
1. Navigate to /ar and look at the site logo
2. Notice there is no longer any white space above or below the logo

Example: http://bigbite.im/i/KRHA1l
