### PR TITLE
Section Padding and Full Image with Buttons Pattern text colour

### DIFF
--- a/private/src/styles/blocks/section/_editor.scss
+++ b/private/src/styles/blocks/section/_editor.scss
@@ -6,3 +6,11 @@
 .section--has-bg-overlay::before {
   z-index: 0 !important;
 }
+
+.section--textWhite {
+  color: var(--wp--preset--color--white);
+
+  @include headings {
+    color: var(--wp--preset--color--white);
+  }
+}

--- a/private/src/styles/blocks/section/_editor.scss
+++ b/private/src/styles/blocks/section/_editor.scss
@@ -8,9 +8,9 @@
 }
 
 .section--textWhite {
-  color: var(--wp--preset--color--white);
+  color: var(--wp--preset--color--white) !important;
 
   @include headings {
-    color: var(--wp--preset--color--white);
+    color: var(--wp--preset--color--white) !important;
   }
 }

--- a/private/src/styles/blocks/section/_main.scss
+++ b/private/src/styles/blocks/section/_main.scss
@@ -4,10 +4,6 @@
   color: var(--wp--preset--color--black);
 }
 
-.section:first-of-type {
-  padding-top: 0;
-}
-
 .section.is-fullWidth--mobile,
 .section.is-fullWidth--mobile .container {
   @include mq($until: small) {

--- a/private/src/styles/blocks/section/_main.scss
+++ b/private/src/styles/blocks/section/_main.scss
@@ -4,6 +4,10 @@
   color: var(--wp--preset--color--black);
 }
 
+.section:first-of-type {
+  padding-top: 0;
+}
+
 .section.is-fullWidth--mobile,
 .section.is-fullWidth--mobile .container {
   @include mq($until: small) {

--- a/private/src/styles/pages/_single.scss
+++ b/private/src/styles/pages/_single.scss
@@ -2,10 +2,6 @@
   margin-bottom: var(--wp--preset--spacing--single);
 }
 
-.article-content {
-  margin: var(--wp--preset--spacing--single) 0;
-}
-
 .article-footer .article-meta {
   margin-bottom: var(--wp--preset--spacing--single);
 }

--- a/private/src/styles/pages/article/_base.scss
+++ b/private/src/styles/pages/article/_base.scss
@@ -88,10 +88,6 @@
   text-decoration: none;
 }
 
-.article-content .section:not(.section--tinted):not(.section--has-bg-image) {
-  padding: 0;
-}
-
 .article-content .btn {
   text-decoration: none;
 }

--- a/private/src/styles/pages/article/_base.scss
+++ b/private/src/styles/pages/article/_base.scss
@@ -12,7 +12,6 @@
 
 .article-container {
   @include flexy-wrapper;
-  margin-top: var(--wp--preset--spacing--single);
 
   @include mq(large) {
     flex-wrap: nowrap;


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/246

Fixes issue with broken padding on sections with FSE changes by removing a now unnecessary css rule.
Also fixes the text colour not changing in the Editor for Full Image with Buttons pattern

**Steps to test**:
1. For section padding, navigate the front end of the site and check the padding is correct on pages and posts
2. For text colour change, edit a post and insert the Full Image with Buttons pattern
3. Highlight the section and change the text colour
4. The heading should now change accordingly

Example: 
Padding: http://bigbite.im/i/gAfRu2
Text Colour: http://bigbite.im/v/sTqUtn
