### PR TITLE
Replaces custom quote with core quote in patterns

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/66-33-text-with-image.php
+++ b/wp-content/themes/humanity-theme/patterns/66-33-text-with-image.php
@@ -27,7 +27,11 @@
 <p class="has-text-align-left">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Congue nisi vitae suscipit tellus mauris a. Scelerisque fermentum dui faucibus in ornare quam viverra. Imperdiet proin fermentum leo vel orci porta non. </p>
 <!-- /wp:paragraph -->
 
-<!-- wp:amnesty-core/quote {"align":"start","size":"medium","content":"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.","citation":"orci sagittis eu volutpat odio"} /-->
+<!-- wp:quote {"textAlign":"left","fontSize":"small"} -->
+<blockquote class="wp-block-quote has-text-align-left has-small-font-size"><!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+<!-- /wp:paragraph --><cite>orci sagittis eu volutpat odio</cite></blockquote>
+<!-- /wp:quote -->
 
 <!-- wp:paragraph {"align":"left"} -->
 <p class="has-text-align-left">A arcu cursus vitae congue mauris rhoncus aenean vel elit. Condimentum vitae sapien pellentesque habitant morbi tristique senectus et netus. Habitant morbi tristique senectus et netus et malesuada fames ac. Scelerisque mauris pellentesque pulvinar pellentesque habitant morbi tristique senectus. Volutpat diam ut venenatis tellus in metus vulputate. </p>

--- a/wp-content/themes/humanity-theme/patterns/audio-quote.php
+++ b/wp-content/themes/humanity-theme/patterns/audio-quote.php
@@ -10,6 +10,13 @@
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:audio /-->
-
-<!-- wp:amnesty-core/quote {"align":"","content":"","citation":""} /--></div>
+	<!-- wp:quote -->
+	<blockquote class="wp-block-quote">
+		<!-- wp:paragraph -->
+		<p></p>
+		<!-- /wp:paragraph -->
+		<cite>- (Add Citation)</cite>
+	</blockquote>
+	<!-- /wp:quote -->
+</div>
 <!-- /wp:group -->

--- a/wp-content/themes/humanity-theme/patterns/quote-audio.php
+++ b/wp-content/themes/humanity-theme/patterns/quote-audio.php
@@ -9,7 +9,14 @@
 ?>
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:amnesty-core/quote {"align":"","content":"","citation":""} /-->
-
-<!-- wp:audio /--></div>
+<div class="wp-block-group">
+	<!-- wp:quote -->
+	<blockquote class="wp-block-quote">
+		<!-- wp:paragraph -->
+		<p></p>
+		<!-- /wp:paragraph -->
+		<cite>- (Add Citation)</cite>
+	</blockquote>
+	<!-- /wp:quote -->
+	<!-- wp:audio /--></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/246

Replaces all instances of the custom quote block with the core quote block in patterns

**Steps to test**:
1. Edit a post
2. Open the block/pattern inserter
3. Search Quote
4. Insert all the patterns containing quote blocks
5. Notice they now use the core quote block instead of the custom quote block

Example: http://bigbite.im/i/lDVRtN
