### PR TITLE
Fixes post list styling for country pages

### DIFF
--- a/private/src/styles/blocks/postlist/_main.scss
+++ b/private/src/styles/blocks/postlist/_main.scss
@@ -6,5 +6,8 @@
 
 .postlist {
   display: flex;
-  flex-wrap: wrap;
+
+  @include mq($until: medium-sm) {
+    flex-wrap: wrap;
+  }
 }

--- a/private/src/styles/blocks/postlist/_post.scss
+++ b/private/src/styles/blocks/postlist/_post.scss
@@ -1,6 +1,22 @@
 .post {
   position: relative;
   width: 100%;
+
+  @include mq(medium-sm) {
+    min-height: 460px;
+  }
+}
+
+@include mq(medium-sm) {
+  .tax-location .post+.post {
+    margin-left: flexy-gutter();
+  }
+}
+
+@include mq($until: medium-sm) {
+  .tax-location .post+.post {
+    margin-top: flexy-gutter();
+  }
 }
 
 .post-header {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/246

Fixes post list styling for country pages

**Steps to test**:
1. Navigate to a country page/region or sub-region
2. Scroll to the News, Urgent Actions or Research sections
3. They should now appear as expected
4. Reduce the window size and they should respond as expected also

Example: http://bigbite.im/v/oXji2R