### PR TITLE
Counter Block Line Height

### DIFF
--- a/private/src/styles/blocks/stat-counter/_main.scss
+++ b/private/src/styles/blocks/stat-counter/_main.scss
@@ -2,6 +2,7 @@
   font-family: var(--wp--preset--font-family--secondary);
   font-size: 85px;
   font-weight: bold;
+  line-height: normal;
 }
 
 .wp-block-amnesty-core-counter.aligncenter {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/246

Fixes the line height issue with the counter block, by overriding theme.json default line height value

**Steps to test**:
1. Edit a post and insert a counter block
2. Populate with content
3. Save and view the front end
4. No elements should now overlap and should be spaced correctly

Example: http://bigbite.im/i/V7EtOX
