### PR TITLE
Fix old header rendering

### DIFF
--- a/private/src/styles/layout/_page-hero.scss
+++ b/private/src/styles/layout/_page-hero.scss
@@ -19,6 +19,10 @@
   }
 }
 
+.page-hero:has(+ main) {
+  margin-bottom: var(--wp--preset--spacing--double);
+}
+
 .page-header--light ~ .page-hero,
 .page-header--shaded ~ .page-hero {
   padding-top: 80px;

--- a/wp-content/themes/humanity-theme/includes/kses/wp-kses-post.php
+++ b/wp-content/themes/humanity-theme/includes/kses/wp-kses-post.php
@@ -35,3 +35,21 @@ if ( ! function_exists( 'amnesty_wp_kses_post_allowed_html' ) ) {
 }
 
 add_filter( 'wp_kses_allowed_html', 'amnesty_wp_kses_post_allowed_html', 100, 2 );
+
+if ( ! function_exists( 'amnesty_wp_kses_post_allow_style_tag' ) ) {
+	/**
+	 * Allow the <style> tag to be output
+	 *
+	 * @param array<string,mixed> $tags    allowed tags
+	 * @param string              $context the kses context
+	 *
+	 * @return array<string,mixed>
+	 */
+	function amnesty_wp_kses_post_allow_style_tag( array $tags, string $context ): array {
+		if ( 'post' === $context ) {
+			$tags['style'] = [];
+		}
+
+		return $tags;
+	}
+}

--- a/wp-content/themes/humanity-theme/patterns/featured-image.php
+++ b/wp-content/themes/humanity-theme/patterns/featured-image.php
@@ -9,7 +9,7 @@
 
 use Amnesty\Get_Image_Data;
 
-if ( amnesty_post_has_hero() ) {
+if ( amnesty_post_has_hero() || amnesty_post_has_header() ) {
 	return;
 }
 

--- a/wp-content/themes/humanity-theme/patterns/post-header.php
+++ b/wp-content/themes/humanity-theme/patterns/post-header.php
@@ -19,7 +19,9 @@ if ( ! array_filter( $hero_data ) ) {
 	return;
 }
 
+add_filter( 'wp_kses_allowed_html', 'amnesty_wp_kses_post_allow_style_tag', 10, 2 );
 echo wp_kses_post( amnesty_render_header_block( $hero_data['attrs'], $hero_data['content'] ) );
+remove_filter( 'wp_kses_allowed_html', 'amnesty_wp_kses_post_allow_style_tag', 10, 2 );
 
 if ( ! is_admin() ) {
 	add_filter( 'the_content', 'amnesty_remove_header_from_content', 0 );

--- a/wp-content/themes/humanity-theme/templates/single.html
+++ b/wp-content/themes/humanity-theme/templates/single.html
@@ -1,3 +1,5 @@
+<!-- wp:pattern {"slug":"amnesty/post-hero"} /-->
+
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
     <!-- wp:pattern {"slug":"amnesty/featured-image"} /-->


### PR DESCRIPTION
Style tag was being escaped, leaving the CSS
to be output as a string.
This fix allows the style tag to be output
without being stripped by KSES only whilst
the header block is being rendered.
Since the CSS being rendered is properly
escaped in the renderer, this should be
acceptable.

Ref: https://github.com/amnestywebsite/humanity-theme/issues/246

**Steps to test**:
1. Visit a page that's using the old header block, or add it via code view
2. View the frontend
3. the styles should be output correctly - the background image on the block should render
