### PR TITLE
Add padding around categories container

### DIFF
--- a/private/src/styles/blocks/postlist/_categories.scss
+++ b/private/src/styles/blocks/postlist/_categories.scss
@@ -10,7 +10,7 @@
 .postlist-categories {
   display: flex;
   flex: 1 1 100%;
-  padding: 0 20px;
+  padding: 20px;
   margin-bottom: 0;
   margin-left: 0;
   max-width: 100%;


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/246

**Steps to test**:
1. visit what we do -> armed conflict
2. see that there now exists vertical padding on the `.postlist-categories` element
3. visit latest
4. the filters should maintain their standard padding 
