### PR TITLE
Fix page number URIs on searchpage

### DIFF
--- a/wp-content/themes/humanity-theme/includes/core-blocks/query/pagination/numbers.php
+++ b/wp-content/themes/humanity-theme/includes/core-blocks/query/pagination/numbers.php
@@ -70,12 +70,16 @@ if ( ! function_exists( 'amnesty_render_block_core_query_pagination_numbers' ) )
 			$wp_query      = $block_query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- taken from core
 			$total         = ! $max_page || $max_page > $wp_query->max_num_pages ? $wp_query->max_num_pages : $max_page;
 			$paginate_args = [
-				'base'      => '%_%',
-				'format'    => $pretty_pagination ? '/page/%#%/' : "?$page_key=%#%", // this was changed from core - @jaymcp
 				'current'   => max( 1, $page ),
 				'total'     => $total,
 				'prev_next' => false,
 			];
+
+			// this was changed from core - @jaymcp
+			if ( ! $pretty_pagination ) {
+				$paginate_args['base']   = '%_%';
+				$paginate_args['format'] = "?{$page_key}=%#%";
+			}
 
 			if ( null !== $mid_size ) {
 				$paginate_args['mid_size'] = $mid_size;


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/246

**Steps to test**:
1. visit the search page (no search term)
2. click on a page number
3. you should remain on the search page 
4. the uri suffix should be `/page/n/`, where `n` is the number you clicked
