### PR TITLE
Prevent postlist collapsing width

### DIFF
--- a/private/src/styles/pages/_news.scss
+++ b/private/src/styles/pages/_news.scss
@@ -8,6 +8,10 @@
   }
 }
 
+.blog .postlist .wp-block-post-template.columns-4 {
+  width: 100%;
+}
+
 .has-subcategories {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/246

**Steps to test**:
1. view the blog index
2. posts should retain 4 column layout, and should fill the parent container (minus gutters)
3. click a page number
4. repeat step 2

