### PR TITLE
Add Option for forcing thousand separator for stats counter block

### DIFF
--- a/private/src/scripts/editor/blocks/stat-counter/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/stat-counter/DisplayComponent.jsx
@@ -5,6 +5,7 @@ const { BlockAlignmentToolbar, BlockControls, InspectorControls } = wp.blockEdit
 const { Button, RangeControl, TextControl, ToolbarGroup, PanelBody } = wp.components;
 const { Component, Fragment } = wp.element;
 const { __ } = wp.i18n;
+const { currentLocale = 'en-GB', enforceGroupingSeparators } = window.amnestyCoreI18n;
 
 const toRawNumber = (value = '0') => {
   if (isInteger(value)) {
@@ -17,13 +18,19 @@ const toRawNumber = (value = '0') => {
   return inted;
 };
 
+// format a value as a locale-aware number
 const toFormattedString = (value) => {
   if (!value) {
     return '';
   }
 
-  const { currentLocale = 'en-GB' } = window.amnestyCoreI18n;
-  const formatted = toRawNumber(value).toLocaleString(currentLocale.replace('_', '-'));
+  const options = {};
+
+  if (enforceGroupingSeparators) {
+    options.useGrouping = true;
+  }
+
+  const formatted = toRawNumber(value).toLocaleString(currentLocale.replace('_', '-'), options);
 
   return formatted;
 };

--- a/private/src/scripts/modules/counter.js
+++ b/private/src/scripts/modules/counter.js
@@ -19,7 +19,18 @@ const toFormattedString = (value) => {
   }
 
   const { currentLocale = 'en-GB' } = window.amnestyCoreI18n;
-  const formatted = toRawNumber(value).toLocaleString(currentLocale.replace('_', '-'));
+
+  const { forceTS } = window.amnestyForceTS;
+
+  let formatted = '';
+
+  if (forceTS === 'on') {
+    formatted = toRawNumber(value).toLocaleString(currentLocale.replace('_', '-'), {
+      useGrouping: true,
+    });
+  } else {
+    formatted = toRawNumber(value).toLocaleString(currentLocale.replace('_', '-'));
+  }
 
   return formatted;
 };

--- a/private/src/scripts/modules/counter.js
+++ b/private/src/scripts/modules/counter.js
@@ -20,17 +20,15 @@ const toFormattedString = (value) => {
 
   const { currentLocale = 'en-GB' } = window.amnestyCoreI18n;
 
-  const { forceTS } = window.amnestyForceTS;
+  const { forceThousandSeparator } = window.amnestyForceThousandSeparator;
 
-  let formatted = '';
+  let options = '';
 
-  if (forceTS === 'on') {
-    formatted = toRawNumber(value).toLocaleString(currentLocale.replace('_', '-'), {
-      useGrouping: true,
-    });
-  } else {
-    formatted = toRawNumber(value).toLocaleString(currentLocale.replace('_', '-'));
+  if (forceThousandSeparator) {
+    options = { useGrouping: true };
   }
+
+  const formatted = toRawNumber(value).toLocaleString(currentLocale.replace('_', '-'), options);
 
   return formatted;
 };

--- a/private/src/scripts/modules/counter.js
+++ b/private/src/scripts/modules/counter.js
@@ -1,4 +1,5 @@
 const { isInteger } = lodash;
+const { currentLocale = 'en-GB', enforceGroupingSeparators } = window.amnestyCoreI18n;
 
 // ensure value is an int
 const toRawNumber = (value = '0') => {
@@ -18,14 +19,10 @@ const toFormattedString = (value) => {
     return '';
   }
 
-  const { currentLocale = 'en-GB' } = window.amnestyCoreI18n;
+  const options = {};
 
-  const { forceThousandSeparator } = window.amnestyForceThousandSeparator;
-
-  let options = '';
-
-  if (forceThousandSeparator) {
-    options = { useGrouping: true };
+  if (enforceGroupingSeparators) {
+    options.useGrouping = true;
   }
 
   const formatted = toRawNumber(value).toLocaleString(currentLocale.replace('_', '-'), options);

--- a/private/src/styles/admin/_localisation-options.scss
+++ b/private/src/styles/admin/_localisation-options.scss
@@ -25,6 +25,6 @@
   margin-left: 25px;
 }
 
-.cmb2-id-force-thousands-separator .cmb-td label {
+.cmb2-id-enforce-grouping-separators .cmb-td label {
   margin-left: 25px;
 }

--- a/private/src/styles/admin/_localisation-options.scss
+++ b/private/src/styles/admin/_localisation-options.scss
@@ -24,3 +24,7 @@
 .cmb2-wrap .cmb2-id-ol-locale-option li {
   margin-left: 25px;
 }
+
+.cmb2-id-force-thousands-separator .cmb-td label {
+  margin-left: 25px;
+}

--- a/wp-content/themes/humanity-theme/includes/admin/theme-options/localisation.php
+++ b/wp-content/themes/humanity-theme/includes/admin/theme-options/localisation.php
@@ -128,6 +128,7 @@ if ( ! function_exists( 'amnesty_register_localisation_options' ) ) {
 				'id'      => 'force_thousands_separator',
 				'type'    => 'checkbox',
 				'default' => 0,
+				'desc'    => __( 'Force the use of thousand separators for the Stat Counter block, for example for Spanish speaking countries "3.345"', 'amnesty' ),
 			]
 		);
 

--- a/wp-content/themes/humanity-theme/includes/admin/theme-options/localisation.php
+++ b/wp-content/themes/humanity-theme/includes/admin/theme-options/localisation.php
@@ -120,15 +120,15 @@ if ( ! function_exists( 'amnesty_register_localisation_options' ) ) {
 			]
 		);
 
-		// Add a checkbox for forcing thousands separator
 		$localisation->add_field(
 			[
 				/* translators: [admin] */
-				'name'    => __( 'Force Thousands Separator', 'amnesty' ),
-				'id'      => 'force_thousands_separator',
+				'name'    => __( 'Always display numeric grouping separators', 'amnesty' ),
+				'id'      => 'enforce_grouping_separators',
 				'type'    => 'checkbox',
 				'default' => 0,
-				'desc'    => __( 'Force the use of thousand separators for the Stat Counter block, for example for Spanish speaking countries "3.345"', 'amnesty' ),
+				/* translators: [admin] */
+				'desc'    => __( 'Whether to use numeric grouping separators, such as thousands separators, even if the locale prefers otherwise.', 'amnesty' ),
 			]
 		);
 

--- a/wp-content/themes/humanity-theme/includes/admin/theme-options/localisation.php
+++ b/wp-content/themes/humanity-theme/includes/admin/theme-options/localisation.php
@@ -23,7 +23,7 @@ if ( ! function_exists( 'amnesty_register_localisation_options' ) ) {
 				'tab_title'    => __( 'Localisation', 'amnesty' ),
 				'parent_slug'  => 'amnesty_theme_options_page',
 				'display_cb'   => 'amnesty_options_display_with_tabs',
-			] 
+			]
 		);
 
 		$localisation->add_field(
@@ -117,7 +117,18 @@ if ( ! function_exists( 'amnesty_register_localisation_options' ) ) {
 					/* translators: [admin] */
 					'upper-roman'           => __( 'Uppercase Roman numerals.', 'amnesty' ),
 				],
-			] 
+			]
+		);
+
+		// Add a checkbox for forcing thousands separator
+		$localisation->add_field(
+			[
+				/* translators: [admin] */
+				'name'    => __( 'Force Thousands Separator', 'amnesty' ),
+				'id'      => 'force_thousands_separator',
+				'type'    => 'checkbox',
+				'default' => 0,
+			]
 		);
 
 		do_action( 'amnesty_register_localisation_options', $localisation );

--- a/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
@@ -28,7 +28,7 @@ if ( ! function_exists( 'render_stat_counter_block' ) ) {
 		$duration  = $attributes['duration'];
 		$value     = $attributes['value'];
 
-		if ( $options['force_thousands_separator'] === 'on' ) {
+		if ( 'on' === $options['force_thousands_separator'] ) {
 			$value = number_format_i18n( $value );
 		}
 

--- a/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
@@ -13,6 +13,8 @@ if ( ! function_exists( 'render_stat_counter_block' ) ) {
 	 * @return string
 	 */
 	function render_stat_counter_block( array $attributes ): string {
+		$options = get_option( 'amnesty_localisation_options_page' );
+
 		$attributes = wp_parse_args(
 			$attributes,
 			[
@@ -26,6 +28,14 @@ if ( ! function_exists( 'render_stat_counter_block' ) ) {
 		$duration  = $attributes['duration'];
 		$value     = $attributes['value'];
 
+		if ( $options['force_thousands_separator'] === 'on') {
+			$value = number_format( intval($value) );
+
+			echo '<pre>';
+			var_dump($value);
+			echo '</pre>';
+		}
+
 		$wrapper_attributes = get_block_wrapper_attributes(
 			[
 				'class' => $alignment,
@@ -37,7 +47,7 @@ if ( ! function_exists( 'render_stat_counter_block' ) ) {
 			wp_kses_data( $wrapper_attributes ),
 			esc_attr( $duration ),
 			esc_attr( $value ),
-			wp_kses_post( $value )
+			$value
 		);
 	}
 }

--- a/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
@@ -28,12 +28,8 @@ if ( ! function_exists( 'render_stat_counter_block' ) ) {
 		$duration  = $attributes['duration'];
 		$value     = $attributes['value'];
 
-		if ( $options['force_thousands_separator'] === 'on') {
-			$value = number_format( intval($value) );
-
-			echo '<pre>';
-			var_dump($value);
-			echo '</pre>';
+		if ( $options['force_thousands_separator'] === 'on' ) {
+			$value = number_format_i18n( $value );
 		}
 
 		$wrapper_attributes = get_block_wrapper_attributes(
@@ -47,7 +43,7 @@ if ( ! function_exists( 'render_stat_counter_block' ) ) {
 			wp_kses_data( $wrapper_attributes ),
 			esc_attr( $duration ),
 			esc_attr( $value ),
-			$value
+			wp_kses_post( $value )
 		);
 	}
 }

--- a/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
@@ -28,7 +28,7 @@ if ( ! function_exists( 'render_stat_counter_block' ) ) {
 		$duration  = $attributes['duration'];
 		$value     = $attributes['value'];
 
-		if ( 'on' === $options['force_thousands_separator'] ) {
+		if ( 'on' === $options['enforce_grouping_separators'] ) {
 			$value = number_format_i18n( $value );
 		}
 

--- a/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
@@ -347,3 +347,27 @@ if ( ! function_exists( 'amnesty_disable_cart_fragments' ) ) {
 }
 
 add_action( 'wp_enqueue_scripts', 'amnesty_disable_cart_fragments', 200 );
+
+if ( ! function_exists( 'amnesty_force_thousands_separator_localisation' ) ) {
+	/**
+	 * Localise the thousands separator option
+	 *
+	 * @package Amnesty\ThemeSetup
+	 *
+	 * @return void
+	 */
+	function amnesty_force_thousands_separator_localisation() {
+
+		$force_thousands_separator = get_option( 'amnesty_localisation_options_page' )['force_thousands_separator'] ?? 'off';
+
+		$data = [
+			'forceTS' => $force_thousands_separator,
+		];
+
+		wp_localize_script( 'amnesty-theme', 'amnestyForceTS', $data );
+		wp_localize_script( 'amnesty-core-blocks-js', 'amnestyForceTS', $data );
+	}
+}
+
+add_action( 'enqueue_block_editor_assets', 'amnesty_force_thousands_separator_localisation' );
+add_action( 'wp_loaded', 'amnesty_force_thousands_separator_localisation' );

--- a/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
@@ -360,11 +360,11 @@ if ( ! function_exists( 'amnesty_force_thousands_separator_localisation' ) ) {
 		$force_thousands_separator = get_option( 'amnesty_localisation_options_page' )['force_thousands_separator'] ?? 'off';
 
 		$data = [
-			'forceTS' => $force_thousands_separator,
+			'forceThousandSeparator' => amnesty_validate_boolish( $force_thousands_separator ),
 		];
 
-		wp_localize_script( 'amnesty-theme', 'amnestyForceTS', $data );
-		wp_localize_script( 'amnesty-core-blocks-js', 'amnestyForceTS', $data );
+		wp_localize_script( 'amnesty-theme', 'amnestyForceThousandSeparator', $data );
+		wp_localize_script( 'amnesty-core-blocks-js', 'amnestyForceThousandSeparator', $data );
 	}
 }
 

--- a/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
@@ -240,6 +240,11 @@ if ( ! function_exists( 'amnesty_localise_javascript' ) ) {
 			'currentLocale'    => get_locale(),
 		];
 
+		$options = get_option( 'amnesty_localisation_options_page' );
+		if ( isset( $options['enforce_grouping_separators'] ) ) {
+			$data['enforceGroupingSeparators'] = 'on' === $options['enforce_grouping_separators'];
+		}
+
 		wp_localize_script( 'amnesty-theme', 'amnestyCoreI18n', $data );
 		wp_localize_script( 'amnesty-core-blocks-js', 'amnestyCoreI18n', $data );
 	}
@@ -347,26 +352,3 @@ if ( ! function_exists( 'amnesty_disable_cart_fragments' ) ) {
 }
 
 add_action( 'wp_enqueue_scripts', 'amnesty_disable_cart_fragments', 200 );
-
-if ( ! function_exists( 'amnesty_force_thousands_separator_localisation' ) ) {
-	/**
-	 * Localise the thousands separator option
-	 *
-	 * @package Amnesty\ThemeSetup
-	 *
-	 * @return void
-	 */
-	function amnesty_force_thousands_separator_localisation() {
-		$force_thousands_separator = get_option( 'amnesty_localisation_options_page' )['force_thousands_separator'] ?? 'off';
-
-		$data = [
-			'forceThousandSeparator' => amnesty_validate_boolish( $force_thousands_separator ),
-		];
-
-		wp_localize_script( 'amnesty-theme', 'amnestyForceThousandSeparator', $data );
-		wp_localize_script( 'amnesty-core-blocks-js', 'amnestyForceThousandSeparator', $data );
-	}
-}
-
-add_action( 'enqueue_block_editor_assets', 'amnesty_force_thousands_separator_localisation' );
-add_action( 'wp_loaded', 'amnesty_force_thousands_separator_localisation' );

--- a/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/scripts-and-styles.php
@@ -357,7 +357,6 @@ if ( ! function_exists( 'amnesty_force_thousands_separator_localisation' ) ) {
 	 * @return void
 	 */
 	function amnesty_force_thousands_separator_localisation() {
-
 		$force_thousands_separator = get_option( 'amnesty_localisation_options_page' )['force_thousands_separator'] ?? 'off';
 
 		$data = [


### PR DESCRIPTION
Epic: https://github.com/amnestywebsite/humanity-theme/issues/417
Issue: https://github.com/amnestywebsite/humanity-theme/issues/5

Adds a checkbox to the localisation tab inside Theme Options that forces the use of thousand separators on the stats counter block.

**Steps to test**:
1. Before checking out this branch, edit a post on /es/
2. Insert a counter block and populate with a number > 999 but < 10,000
3. Save and view the front end.
4. Notice the number will have no thousand separator.
5. Checkout this branch and run a build
6. Go to es/wp-admin/admin.php?page=amnesty_localisation_options_page
7. There should now be a checkbox for "Force Thousands Separator"
8. Check this, and save.
9. Now return to your counter block front end and refresh
10. The number should now display with a thousand separator (e.g. 3.445 for Spanish)

**Considerations**:
- Localisation

Example: http://bigbite.im/v/Rl4WKF
