### PR TITLE
Retrieve featured image correctly

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/featured-image.php
+++ b/wp-content/themes/humanity-theme/patterns/featured-image.php
@@ -36,7 +36,7 @@ $attributes = [
 <!-- wp:group {"tagName":"div","className":"container container--feature"} -->
 <div class="wp-block-group container container--feature">
 	<!-- wp:image <?php echo wp_kses_data( wp_json_encode( $attributes ) ); ?> -->
-	<figure class="wp-block-image <?php echo esc_attr( $attributes['className'] ); ?>"><img src="<?php echo esc_url( wp_get_attachment_url( $image_id ) ); ?>" alt="" class="wp-image-<?php echo absint( $image_id ); ?>"/></figure>
+	<figure class="wp-block-image <?php echo esc_attr( $attributes['className'] ); ?>"><img src="<?php echo esc_url( amnesty_get_attachment_image_src( $image_id, 'hero-md' ) ); ?>" alt="" class="wp-image-<?php echo absint( $image_id ); ?>"/></figure>
 	<!-- /wp:image -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
If Multisite Global Media is enabled and
used for the featured image, it will fail
to render.

Ref: https://github.com/amnestywebsite/humanity-theme/issues/384

**Steps to test**:
1. assuming multisite global media plugin is enabled
2. before checking out, insert an image from the global media library to a post featured image
3. view the frontend
4. the image won't render
5. checkout this PR
6. reload the frontend
7. the image should load
