### PR TITLE
Add documents into search page query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Fixes:
 - Typo in content maximisation conditionals
 - Search page taxonomy filters
+- Missing page title when page has no Hero
 
 ### v2.0.4
 Fixes:

--- a/wp-content/themes/humanity-theme/includes/features/search/class-search-page.php
+++ b/wp-content/themes/humanity-theme/includes/features/search/class-search-page.php
@@ -105,6 +105,10 @@ class Search_Page {
 			's'         => get_query_var( 's' ),
 		];
 
+		if ( defined( 'SP_FILE' ) ) {
+			$vars['SHAREPOINT_SEARCH_FILTERS'] = true;
+		}
+
 		return array_filter( $vars );
 	}
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2987

**Steps to test**:
1. visit the search page
2. filter by "urgent action" resource type
3. sharepoint docs should show in the results
