### PR TITLE
Menu block padding fix

### DIFF
--- a/private/src/styles/blocks/postlist/_categories-editor.scss
+++ b/private/src/styles/blocks/postlist/_categories-editor.scss
@@ -7,7 +7,7 @@
   align-items: flex-start;
   box-sizing: border-box !important;
   margin: 0 !important;
-  padding: 0 20px !important;
+  padding: 20px !important;
   list-style: none !important;
 
   a {

--- a/private/src/styles/blocks/postlist/_categories.scss
+++ b/private/src/styles/blocks/postlist/_categories.scss
@@ -10,7 +10,7 @@
 .postlist-categories {
   display: flex;
   flex: 1 1 100%;
-  padding: 20px;
+  padding: 20px !important;
   margin-bottom: 0;
   margin-left: 0;
   max-width: 100%;


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/457

Ensures the padding is added to the menu block in both the editor and on the front end

**Steps to test**:
1. Edit a post
2. Add the menu block and pick a menu
3. Change background to grey for more visibility
4. Notice the padding in the editor
5. Save or preview on the front end
6. Notice the padding on the front end

Example:
Frontend: http://bigbite.im/i/8hnwRN
Editor: http://bigbite.im/i/ZUN7m0