### PR TITLE
Fix appearance of post list in block editor

### DIFF
--- a/private/src/styles/blocks/postlist/_post-editor.scss
+++ b/private/src/styles/blocks/postlist/_post-editor.scss
@@ -1,0 +1,14 @@
+.wp-block-bigbite-postlist .post {
+  min-height: auto !important;
+  align-items: center;
+
+  &:hover {
+    background-color: color-mix(in srgb, var(--wp--preset--color--black) 5%, transparent);;
+  }
+}
+
+.wp-block-bigbite-postlist label,
+.wp-block-bigbite-postlist input,
+.wp-block-bigbite-postlist select {
+  text-transform: none;
+}

--- a/private/src/styles/gutenberg.scss
+++ b/private/src/styles/gutenberg.scss
@@ -105,6 +105,7 @@
 @import "blocks/tweet-action/tweet";
 @import "blocks/tweet-action/editor";
 @import "blocks/postlist/main";
+@import "blocks/postlist/post-editor";
 
 // Block Patterns
 @import "block-patterns/group";


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-petitions/issues/13

**Steps to test**:
1. edit a post
2. insert a post list block / petition list block
3. switch to object selection mode
4. each item in the list of objects to choose from should not be inordinately large
5. the content within each item (image, title, plus button) should be aligned nicely
6. hovering over an item should now indicate the current item with a subtle background colour, in addition to the plus button

