### PR TITLE
Adds a specific font size to override the default h1

### DIFF
--- a/private/src/styles/pages/article/_base.scss
+++ b/private/src/styles/pages/article/_base.scss
@@ -64,12 +64,7 @@
 
 .article-title {
   margin-bottom: 0;
-
-  font-size: 32px;
-
-  @include mq(small) {
-    font-size: 52px;
-  }
+  font-size: var(--wp--preset--font-size--article-title);
 }
 
 .article-termWrapper {

--- a/wp-content/themes/humanity-theme/theme.json
+++ b/wp-content/themes/humanity-theme/theme.json
@@ -353,6 +353,15 @@
           "name": "Heading 6",
           "size": "21px",
           "slug": "heading-6"
+        },
+        {
+          "fluid": {
+            "min": "32px",
+            "max": "52px"
+          },
+          "name": "Article Title",
+          "size": "52px",
+          "slug": "article-title"
         }
       ],
       "dropCap": false,


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2989

Adds specific font size styles to the article title to override the default h1 font size

**Steps to test**:
1. Edit a post
2. Add a post title
3. Save and view the front end
4. Post title should be 52px on viewpoints => 760px and 32px < 760px

Example: http://bigbite.im/i/6pco9U
