### PR TITLE
Custom Card Pattern Fill Container

### DIFF
--- a/private/src/styles/block-patterns/_group.scss
+++ b/private/src/styles/block-patterns/_group.scss
@@ -1,5 +1,5 @@
 .wp-block-group.custom-card {
-  max-width: 350px !important;
+  width:100%;
 
   .wp-block-buttons {
     padding-left: 8px;
@@ -22,13 +22,13 @@
     padding: 10px 10px 0 10px;
   }
 
+  h2 {
+    padding: 10px 10px 0 10px;
+  }
+
   .wp-element-caption {
     padding: 0 10px;
   }
-}
-
-.wp-block-group.custom-card.alignfull {
-  max-width: 480px !important;
 }
 
 .wp-block-group.is-style-light {
@@ -59,4 +59,23 @@
 .wp-block-group.is-style-top-and-bottom-border {
   border-top: 7px solid var(--wp--preset--color--black);
   border-bottom: 7px solid var(--wp--preset--color--black);
+}
+
+.wp-block-group.custom-card .wp-block-image,
+.wp-block-group.custom-card .wp-block-buttons,
+.wp-block-group.custom-card p,
+.wp-block-group.custom-card h2 {
+  max-width: 100%;
+}
+
+.wp-block-group.custom-card img {
+  width: 100%;
+}
+
+.wp-block-group.custom-card .wp-block-button {
+  min-width: 100%;
+}
+
+.wp-block-group.custom-card .wp-block-image > div {
+  width: 100%;
 }

--- a/wp-content/themes/humanity-theme/patterns/custom-card-dark.php
+++ b/wp-content/themes/humanity-theme/patterns/custom-card-dark.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"className":"custom-card is-style-dark","layout":{"type":"constrained","contentSize":"350px","wideSize":"480px"}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"className":"custom-card is-style-dark"} -->
 <div class="wp-block-group custom-card is-style-dark" style="padding-top:8px;padding-bottom:8px"><!-- wp:heading {"textAlign":"center"} -->
 <h2 class="wp-block-heading has-text-align-center">(Label)</h2>
 <!-- /wp:heading -->

--- a/wp-content/themes/humanity-theme/patterns/custom-card-light.php
+++ b/wp-content/themes/humanity-theme/patterns/custom-card-light.php
@@ -8,7 +8,7 @@
  */
 ?>
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"className":"custom-card is-style-light","layout":{"type":"constrained","contentSize":"350px","wideSize":"480px"}} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"8px","bottom":"8px"}}},"className":"custom-card is-style-light"} -->
 <div class="wp-block-group custom-card is-style-light" style="padding-top:8px;padding-bottom:8px"><!-- wp:heading {"textAlign":"center"} -->
 <h2 class="wp-block-heading has-text-align-center">(Label)</h2>
 <!-- /wp:heading -->


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/287

Changes custom card pattern to fill any container, and removes constraints from pattern

**Steps to test**:
1. Edit a post
2. Add a custom card pattern (Dark or Light, Brand has separate PR on the plugin)
3. Notice it fills the whole content area width
4. Add a column block and insert a custom card
5. Notice it fills the column
6. Save and check the same applies for the front end

Example: http://bigbite.im/v/HNQD6h
