### PR TITLE
Add extra check into menu items' retrieval helper

### DIFF
--- a/wp-content/themes/humanity-theme/includes/theme-setup/navigation.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/navigation.php
@@ -144,6 +144,10 @@ if ( ! function_exists( 'amnesty_get_nav_menu_items' ) ) {
 			$menu = wp_get_nav_menu_object( $locations[ $name ] );
 		}
 
+		if ( ! $menu ) {
+			return [];
+		}
+
 		$menu_items = wp_get_nav_menu_items( $menu->term_id, [ 'update_post_term_cache' => false ] );
 		$top_level  = [];
 		$children   = [];


### PR DESCRIPTION
props: @valentin-dassonville

Ref: https://github.com/amnestywebsite/humanity-theme/issues/477

**Steps to test**:
1. prior to checkout, enable `WP_DEBUG` and
2. go to wp-admin -> appearance -> menus
3. unassign any menu set to the `footer-navigation` menu location, if any
4. unassign any menu set to the `footer-legal` menu location, if any
5. view the frontend
6. you should see warnings similar to those shown in the screenshot in the linked ticket
7. checkout this PR
8. the warnings should no longer appear
