### PR TITLE
Add command to compile l10n PHP files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,13 @@
     "updatePoMo": [
       "wp i18n update-po wp-content/themes/humanity-theme/languages/amnesty.pot",
       "wp i18n make-mo wp-content/themes/humanity-theme/languages",
-      "wp i18n make-json wp-content/themes/humanity-theme/languages --no-purge"
+      "wp i18n make-json wp-content/themes/humanity-theme/languages --no-purge",
+      "wp i18n make-php wp-content/themes/humanity-theme/languages"
     ]
   },
   "scripts-descriptions": {
     "lint": "Runs PHP coding standard checks",
     "makePot": "Re-generates the POT language file",
-    "UpdatePoMo": "Updates PO, MO, and JSON translation files"
+    "UpdatePoMo": "Updates PO, MO, JSON, and PHP translation files"
   }
 }


### PR DESCRIPTION
Ref: N/A

**Steps to test**:
1. run `composer updatePoMo`
2. see that `*.l10n.php` files are created
3. disable the translation management plugin, if enabled
4. install and activate query monitor
5. load the frontend
6. open query monitor's languages tab
7. look for the inclusion of the `*.l10n.php` file (see below screenshot)

![](http://bigbite.im/i/zzreOR+)
