### PR TITLE
Set title fallback to blog name

### DIFF
--- a/wp-content/themes/humanity-theme/includes/theme-setup/wp-head.php
+++ b/wp-content/themes/humanity-theme/includes/theme-setup/wp-head.php
@@ -14,8 +14,7 @@ if ( ! function_exists( 'amnesty_wp_title' ) ) {
 		$title = wp_title( '|', false, 'right' );
 
 		if ( ! $title ) {
-			/* translators: [front] */
-			$title = __( 'Amnesty International', 'amnesty' );
+			$title = get_bloginfo( 'name' );
 		}
 
 		printf(


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/523

**Steps to test**:
1. Set the site home page to a static page
2. Visit the home page
3. Check that the output in the `<title>` tag is the site name
