### PR TITLE
Move petition title truncation to CSS

### DIFF
--- a/private/src/styles/blocks/petition-list/_main.scss
+++ b/private/src/styles/blocks/petition-list/_main.scss
@@ -67,6 +67,16 @@
   font-size: var(--wp--preset--font-size--heading-4);
 }
 
+.petition-item .petition-itemTitle > * {
+  // stylelint-disable-next-line value-no-vendor-prefix -- this is necessary
+  display: -webkit-box;
+  line-clamp: 3;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .petition-item .petition-itemExcerpt {
   text-transform: uppercase;
   font-family: var(--wp--preset--font-family--secondary);

--- a/wp-content/themes/humanity-theme/includes/blocks/petition-list/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/petition-list/render.php
@@ -88,9 +88,9 @@ if ( ! function_exists( 'amnesty_render_petition_item' ) ) {
 				<h3 class="petition-itemTitle">
 					<?php
 					if ( ! empty( $data['link'] ) ) {
-						printf( '<a href="%s" tabindex="0">%s</a>', esc_url( $data['link'] ), esc_html( wp_trim_words( $title, 10 ) ) );
+						printf( '<a href="%s" tabindex="0">%s</a>', esc_url( $data['link'] ), esc_html( $title ) );
 					} else {
-						printf( '<span>%s</span>', esc_html( wp_trim_words( $title, 10 ) ) );
+						printf( '<span>%s</span>', esc_html( $title ) );
 					}
 					?>
 				</h3>


### PR DESCRIPTION
WP's word-count truncation truncates characters in Thai, rather than words. Other truncation methods using PHP string manipulation may work, but it is unnecessary computation if we can do the same in CSS.
Although the CSS method does use '-webkit-' browser vendor prefixes, they are supported in all major
browsers (as the spec is still in draft). so this
should allow for a similar experience in modern
browsers, without causing too much layout shift in browsers that don't support it. So it's a reasonable compromise in this specific scenario.

Ref: https://github.com/amnestywebsite/humanity-theme/issues/525

**Steps to test**:
1. add a petition with a very long title
2. if testing on the "main" site, view the petitions index, and skip to step 5, else skip this step
3. insert a petitions list into a page
4. ensure your new petition is in the list
5. its title should be truncated to three lines
