### PR TITLE
Fix incorrect slug reference in Petitions List block

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/petition-list/register.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/petition-list/register.php
@@ -12,9 +12,9 @@ if ( ! function_exists( 'register_petition_list_block' ) ) {
 	 */
 	function register_petition_list_block(): void {
 		$all_types = amnesty_get_post_types();
-		$petition  = get_option( 'aip_petition_slug' ) ?: 'petition';
 
-		if ( ! isset( $all_types[ $petition ] ) ) {
+		// note: this is always "petition", regardless of what is set in permalinks
+		if ( ! isset( $all_types['petition'] ) ) {
 			return;
 		}
 
@@ -45,7 +45,7 @@ if ( ! function_exists( 'register_petition_list_block' ) ) {
 						'default' => $default_petition,
 					],
 				],
-			] 
+			]
 		);
 	}
 }


### PR DESCRIPTION
Ref: N/A

**Steps to test**:
1. before checking out this PR
2. create a petition
3. add a new post
4. insert a petitions list block and save
5. go to settings -> permalinks
6. change the petition url slug to something other than the default of `petition`
7. go to the petitions list view 
8. if the list is empty, the slug didn't update correctly (separate bug), so run `update wp_posts set post_type = 'your-new-slug' where post_type = 'petition';
9. reload the list
10. your petition(s) should be visible again
11. edit the post you created in step 3
12. the petitions list block should still load items
13. preview the post
14. the petitions list block should not render any items
15. checkout this PR
16. reload the post preview
17. the petitions should load