### PR TITLE
Change escaping method for Responsive Iframe caption

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/iframe/views/responsive-iframe.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/iframe/views/responsive-iframe.php
@@ -5,7 +5,7 @@
 
 <?php if ( ! empty( $atts['caption'] ) ) : ?>
 	<figcaption>
-		<p><?php echo esc_html( $atts['caption'] ); ?></p>
+		<p><?php echo wp_kses_post( $atts['caption'] ); ?></p>
 	</figcaption>
 <?php endif; ?>
 </figure>


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/563

**Steps to test**:
1. insert a responsive iframe block
2. add any iframe url
3. add a caption that has some text formatting (bold, italic, href, etc)
4. view the frontend
5. the caption should render correctly
