### PR TITLE
Bug - Post list grid, custom, label only works if a hyperlink is present

### DIFF
--- a/private/src/styles/components/grid/_editor.scss
+++ b/private/src/styles/components/grid/_editor.scss
@@ -246,7 +246,12 @@
 .grid-itemMeta > span {
   padding: 2px 12px;
   background-color: var(--wp--preset--color--black);
+  color: var(--wp--preset--color--white);
   line-height: 1.8;
+}
+
+.grid-itemMeta > span a {
+  color: var(--wp--preset--color--white);
 }
 
 .grid-itemTitle {

--- a/private/src/styles/components/grid/_item.scss
+++ b/private/src/styles/components/grid/_item.scss
@@ -66,6 +66,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   background-color: var(--wp--preset--color--black);
+  color: var(--wp--preset--color--white);
 }
 
 .grid-itemMeta a {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/513

Ensures post list grid label text is always white

**Steps to test**:
1. Insert a post list and change the style to GRID
2. Change the type to CUSTOM
3. Enter label text and it should be white, BUT do not link the text
4. Save the post and view the front end
5. The label text should now be white and visible against the background
6. Change the type to CATEGORY and choose a category
7. Labels should now be white in the editor here as well

Example: http://bigbite.im/v/we3uUF
