### PR TITLE
Bug - Social Icons - Threads icon does not appear on the front end

### DIFF
--- a/private/src/styles/layout/footer/styles/_fse.scss
+++ b/private/src/styles/layout/footer/styles/_fse.scss
@@ -117,7 +117,6 @@
 
 .amnesty-footer-template-part .amnesty-social-group .wp-social-link {
   background: none;
-  color: var(--wp--preset--color--black);
 }
 
 .amnesty-footer-template-part .wp-block-button.is-style-light .wp-block-button__link:hover,


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/576

Removes unnecessary color css from footer social icons

**Steps to test**:
1.  Edit the footer template part
2. Select the social icons and insert a Threads block
3. Add a profile link or #
4. Save and view the front end
5. The threads logo should now be white and visible

Example: http://bigbite.im/i/A30yDB
