### PR TITLE
Bug - meta block - back button arrow not showing on hover

### DIFF
--- a/private/src/styles/blocks/button/styles/_default.scss
+++ b/private/src/styles/blocks/button/styles/_default.scss
@@ -38,3 +38,7 @@
     color: var(--wp--preset--color--black)
   }
 }
+
+.wp-block-button .wp-block-button__link:hover .icon-arrow-left {
+  @include icon(213px, 240px, 16px, 16px);
+}

--- a/private/src/styles/blocks/button/styles/_default.scss
+++ b/private/src/styles/blocks/button/styles/_default.scss
@@ -40,5 +40,9 @@
 }
 
 .wp-block-button .wp-block-button__link:hover .icon-arrow-left {
-  @include icon(213px, 240px, 16px, 16px);
+  @include icon-position(213px, 240px);
+}
+
+.rtl .wp-block-button .wp-block-button__link:hover .icon-arrow-left {
+  @include icon-position(88px, 265px);
 }

--- a/private/src/styles/components/_icon.scss
+++ b/private/src/styles/components/_icon.scss
@@ -7,6 +7,7 @@
 .icon-arrow-left {
   @include icon(234px, 240px, 16px, 16px);
   display: inline-block;
+  transition: background-color 0.3s ease-in-out, border-color 0.3s ease-in-out, color 0.3s ease-in-out;
 
   .rtl & {
     @include icon(110px, 265px, 16px, 16px);

--- a/private/src/styles/components/_icon.scss
+++ b/private/src/styles/components/_icon.scss
@@ -7,7 +7,6 @@
 .icon-arrow-left {
   @include icon(234px, 240px, 16px, 16px);
   display: inline-block;
-  transition: background-color 0.3s ease-in-out, border-color 0.3s ease-in-out, color 0.3s ease-in-out;
 
   .rtl & {
     @include icon(110px, 265px, 16px, 16px);

--- a/private/src/styles/pages/article/_share.scss
+++ b/private/src/styles/pages/article/_share.scss
@@ -19,3 +19,7 @@ ul.article-share {
 .article-share img {
   max-height: 100%;
 }
+
+.rtl ul.article-share {
+  margin: 0;
+}


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/491

Ensures the left arrow on the meta block on posts has the correct hover styles

**Steps to test**:
1. Navigate to a single post on the front end
2. Look for the meta block back button (e.g. < Campaigns)
3. Hover and notice that the arrow is still visible

Example: http://bigbite.im/v/6UZ3Rn