### PR TITLE
Fix initial display of slider navigation arrows

### DIFF
--- a/private/src/styles/blocks/slider/_main.scss
+++ b/private/src/styles/blocks/slider/_main.scss
@@ -116,7 +116,6 @@
   position: absolute;
   top: 50%;
   left: 0;
-  display: none;
   background-color: var(--wp--preset--color--white);
   width: 50px;
   height: 50px;
@@ -138,11 +137,16 @@
 .slides-arrow--next {
   right: 0;
   left: initial;
+  display: block;
 
   .rtl & {
     right: initial;
     left: 0;
   }
+}
+
+.slides-arrow--previous {
+  display: none;
 }
 
 .rtl .slides-arrow--previous {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/15

**Steps to test**:
1. insert a slider with several slides
2. view the frontend
3. the "next slide" indicator arrow should be visible
4. the "previous slide" indicator arrow should not be visible
5. clicking the "next slide" arrow should navigate you to the next slide
6. the "previous slide" arrow should become visible
7. clicking the "previous slide" arrow should navigate you to the previous slide
8. the "previous slide" arrow should then hide again
9. the "next slide" arrow should remain visible
10. navigate to the last slide
11. the "next slide" arrow should hide
12. the "previous slide" arrow should remain visible
13. edit the post
14. in the sidebar options for the slider block
15. toggle the "show tabs" option off
16. repeat steps 3-12
