### PR TITLE
Fix support for language codes

### DIFF
--- a/wp-content/themes/humanity-theme/includes/helpers/site.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/site.php
@@ -2,6 +2,9 @@
 
 declare( strict_types = 1 );
 
+use function Inpsyde\MultilingualPress\languageByTag;
+use function Inpsyde\MultilingualPress\siteLanguageTag;
+
 if ( ! function_exists( 'current_url' ) ) {
 	/**
 	 * Retrieve the current URL
@@ -78,6 +81,14 @@ if ( ! function_exists( 'get_site_language_name' ) ) {
 
 		if ( $override ) {
 			return $override;
+		}
+
+		if ( is_multilingualpress_enabled() ) {
+			$lang = languageByTag( siteLanguageTag( $blog_id ) )?->nativeName();
+
+			if ( $lang ) {
+				return strip_language_name_parentheticals( $lang );
+			}
 		}
 
 		$lang = get_blog_option( $blog_id, 'WPLANG' );

--- a/wp-content/themes/humanity-theme/includes/helpers/site.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/site.php
@@ -106,8 +106,18 @@ if ( ! function_exists( 'strip_language_name_parentheticals' ) ) {
 			return $language;
 		}
 
+		/**
+		 * Since all Chinese locales use the same parent language, we instead use
+		 * the text _within_ the parentheticals, rather than the parent langauge text.
+		 * Otherwise, all would output simply "中文", and there would be no way to differentiate.
+		 */
+		if ( 1 === preg_match( '`^中文`', $language ) ) {
+			$stripped = preg_replace( '/.*?(?:[(（])(.*?)(?:[)）])\s*?/ui', '$1', $language );
+			return $stripped ?: $language;
+		}
+
 		$stripped = preg_replace( '/\s*?([(（]).*?([)）])\s*?/ui', '', $language );
-		return $stripped ?: '';
+		return $stripped ?: $language;
 	}
 }
 

--- a/wp-content/themes/humanity-theme/includes/taxonomies/class-taxonomy-resource-types.php
+++ b/wp-content/themes/humanity-theme/includes/taxonomies/class-taxonomy-resource-types.php
@@ -105,7 +105,7 @@ class Taxonomy_Resource_Types extends Taxonomy {
 		}
 
 		$path  = wp_parse_url( current_url(), PHP_URL_PATH );
-		$regex = sprintf( '#^/[a-z]{2}/%s/([a-z-]+)/$#', preg_quote( $this->slug, '#' ) );
+		$regex = sprintf( '#^/[a-z-_]{2,}/%s/([a-z-]+)/$#', preg_quote( $this->slug, '#' ) );
 
 		// not an old topic url
 		if ( 1 !== preg_match( $regex, $path, $match ) || ! isset( $match[1] ) ) {

--- a/wp-content/themes/humanity-theme/includes/taxonomies/class-taxonomy-topics.php
+++ b/wp-content/themes/humanity-theme/includes/taxonomies/class-taxonomy-topics.php
@@ -104,7 +104,7 @@ class Taxonomy_Topics extends Taxonomy {
 		}
 
 		$path  = wp_parse_url( current_url(), PHP_URL_PATH ) ?: '/';
-		$regex = sprintf( '#^/[a-z]{2}/%s/([a-z-]+)/$#', preg_quote( $this->slug, '#' ) );
+		$regex = sprintf( '#^/[a-z-_]{2,}/%s/([a-z-]+)/$#', preg_quote( $this->slug, '#' ) );
 
 		// not an old topic url
 		if ( 1 !== preg_match( $regex, $path, $match ) || ! isset( $match[1] ) ) {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/3029

we have previously assumed language codes to be two letters, e.g. `es`, `ar`; however, with the introduction of support for Chinese, we can't make that assumption any more. this PR implements changes that allow for language codes such as `zh-Hant`.

**Steps to test**:
1. before checking out this pr
2. create a site in `zh` with the language code `zh-hant` (via MLP), and the url path of `/zh-hant/`; copy across content, but skip attachments
3. attempt to visit a topic uri, e.g. `/zh-hant/topic/armed-conflict/`
4. it should 404
5. attempt to visit a resource type uri, e.g. `/zh-hant/resource-type/action/`
6. it should 404
7. checkout this pr
8. reload the 404 page in step 3
9. it should redirect to search with the topic id pre-filtered, e.g. `/zh-hant/search/?qtopic=2063`
10. reload the 404 page in step 5
11. it should redirect to search with the resource type id pre-filtered, e.g. `/zh-hant/search/qresource-type=1692`
