### PR TITLE
Ensure content is from sites marked as public

### DIFF
--- a/wp-content/themes/humanity-theme/includes/mlp/helpers.php
+++ b/wp-content/themes/humanity-theme/includes/mlp/helpers.php
@@ -2,6 +2,7 @@
 
 declare( strict_types = 1 );
 
+use Inpsyde\MultilingualPress\Framework\Api\Translation;
 use Inpsyde\MultilingualPress\Framework\Api\Translations;
 use Inpsyde\MultilingualPress\Framework\Api\TranslationSearchArgs;
 use Inpsyde\MultilingualPress\Framework\WordpressContext;
@@ -62,6 +63,11 @@ if ( ! function_exists( 'get_object_translations' ) ) {
 		}
 
 		$translations = resolve( Translations::class )->searchTranslations( $args );
+		$translations = array_filter(
+			$translations,
+			fn ( Translation $translation ): bool =>
+				absint( get_blog_option( $translation->remoteSiteId(), 'blog_public', 0 ) ) === 1,
+		);
 
 		wp_cache_add( $cache_key, $translations );
 

--- a/wp-content/themes/humanity-theme/includes/multisite/class-core-site-list.php
+++ b/wp-content/themes/humanity-theme/includes/multisite/class-core-site-list.php
@@ -39,7 +39,7 @@ class Core_Site_List {
 	 */
 	public function __construct() {
 		$this->mo      = new MO();
-		$this->sites   = get_sites();
+		$this->sites   = get_sites( [ 'public' => 1 ] );
 		$this->current = get_current_blog_id();
 	}
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2994

**Steps to test**:
1. in network admin, edit a site
2. under the "attributes" section of the "info" tab, untick the `public` checkbox & save
3. view the home page
4. hover over the language selector dropdown
5. the site should not be in the list of available translations
6. open an incognito window
7. visit the site
8. the site you've marked as not public should no longer be visible in the language selection banner
