### PR TITLE
Rebuild search templates

### DIFF
--- a/private/src/styles/blocks/button/_all.scss
+++ b/private/src/styles/blocks/button/_all.scss
@@ -26,3 +26,4 @@
 @import "./styles/default";
 @import "./styles/dark";
 @import "./styles/link";
+@import "./styles/pagination";

--- a/private/src/styles/blocks/button/_editor.scss
+++ b/private/src/styles/blocks/button/_editor.scss
@@ -31,6 +31,7 @@
   }
 }
 
+.editor-styles-wrapper .wp-block-button.is-style-pagination .wp-block-button__link,
 .wp-block-button.is-style-link .wp-block-button__link {
   background-color: transparent;
   border: none;

--- a/private/src/styles/blocks/button/styles/_pagination.scss
+++ b/private/src/styles/blocks/button/styles/_pagination.scss
@@ -1,0 +1,21 @@
+.wp-block-button.is-style-pagination .wp-block-button__link {
+  color: inherit;
+  border: none;
+  background-color: transparent;
+  font-family: var(--wp--preset--font-family--secondary);
+  font-size: var(--wp--preset--font-size-regular);
+  font-weight: bold;
+  line-height: 1.25;
+  text-transform: uppercase;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    background-color: transparent;
+  }
+}
+
+.wp-block-button.is-style-pagination.is-disabled .wp-block-button__link {
+  cursor: not-allowed;
+  opacity: .5;
+}

--- a/private/src/styles/blocks/postlist/_post-search.scss
+++ b/private/src/styles/blocks/postlist/_post-search.scss
@@ -56,6 +56,11 @@ ul.wp-block-post-template {
   z-index: 2;
   padding-top: 4px;
   padding-bottom: 4px;
+
+  p {
+    margin: 0;
+    display: inline-block;
+  }
 }
 
 .post--result .post-topic {

--- a/private/src/styles/pages/search/_results.scss
+++ b/private/src/styles/pages/search/_results.scss
@@ -49,7 +49,10 @@ body.page-template-searchpage .section .page-search input {
 }
 
 .search-results .wp-block-post-template {
-  margin-left: 0;
+  margin: 0;
+  padding: 0;
+  max-width: 100%;
+  list-style: none;
 }
 
 .search-results .wp-block-post-template .wp-block-post {

--- a/private/src/styles/pages/search/results/_active-filters.scss
+++ b/private/src/styles/pages/search/results/_active-filters.scss
@@ -16,8 +16,13 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
-  margin-bottom: 0;
+  margin: 0;
   list-style: none;
+}
+
+.filter-wrapper .active-filters li {
+  margin-block: 0;
+  margin-inline: var(--wp--preset--spacing--quarter);
 }
 
 .filter-wrapper .clear-filter {

--- a/wp-content/themes/humanity-theme/includes/core-blocks/query/pagination/numbers.php
+++ b/wp-content/themes/humanity-theme/includes/core-blocks/query/pagination/numbers.php
@@ -39,7 +39,7 @@ if ( ! function_exists( 'amnesty_render_block_core_query_pagination_numbers' ) )
 		$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 		$enhanced_pagination = $block->context['enhancedPagination'] ?? false;
 		$page                = absint( $_GET[ $page_key ] ?? $attributes['paged'] ?? 1 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- taken from core
-		$max_page            = (int) $block->context['query']['pages'] ?? 0;
+		$max_page            = (int) ( $block->context['query']['pages'] ?? 0 );
 		$pretty_pagination   = isset( $attributes['pretty'] ) && $attributes['pretty'];
 		$wrapper_attributes  = get_block_wrapper_attributes();
 		$content             = '';

--- a/wp-content/themes/humanity-theme/includes/features/search/class-search-page.php
+++ b/wp-content/themes/humanity-theme/includes/features/search/class-search-page.php
@@ -56,6 +56,11 @@ class Search_Page {
 	public function get_wp_query(): ?WP_Query {
 		if ( is_null( $this->query ) ) {
 			$this->query = new WP_Query( $this->get_query_vars() );
+
+			$search_page_id = absint( get_option( 'amnesty_search_page' ) );
+
+			$this->query->posts = array_filter( $this->query->posts, fn ( $p ): bool => $p->ID !== $search_page_id );
+			$this->query->posts = array_values( $this->query->posts );
 		}
 
 		return $this->query;

--- a/wp-content/themes/humanity-theme/includes/mlp/language-selector.php
+++ b/wp-content/themes/humanity-theme/includes/mlp/language-selector.php
@@ -61,6 +61,7 @@ if ( ! function_exists( 'amnesty_get_object_translations' ) ) {
 				'direction' => $language->isRtl() ? 'rtl' : 'ltr',
 				'name'      => get_blog_option( $translation->remoteSiteId(), 'blogname' ),
 				'url'       => $translation->remoteUrl(),
+				'path'      => get_site( $translation->remoteSiteId() )->path,
 				'blog_id'   => $translation->remoteSiteId(),
 				'item_id'   => $translation->remoteContentId(),
 				'type'      => $translation->type(),

--- a/wp-content/themes/humanity-theme/includes/multisite/helpers.php
+++ b/wp-content/themes/humanity-theme/includes/multisite/helpers.php
@@ -221,22 +221,25 @@ if ( ! function_exists( 'amnesty_get_sites' ) ) {
 	 *
 	 * @package Amnesty\Multisite
 	 *
-	 * @param bool $filter whether to apply filters
+	 * @param bool $filter      whether to apply filters
+	 * @param bool $public_only whether to only return public sites
 	 *
 	 * @return array
 	 */
-	function amnesty_get_sites( bool $filter = true ) {
+	function amnesty_get_sites( bool $filter = true, bool $public_only = true ) {
 		if ( ! defined( 'MULTISITE' ) || ! MULTISITE ) {
 			return [];
 		}
 
-		$cached = wp_cache_get( 'amnesty_get_sites' );
+		$cache_key = implode( '_', [ __FUNCTION__, ( $public_only ? 'public' : 'all' ) ] );
+		$cached    = wp_cache_get( $cache_key );
+
 		if ( is_array( $cached ) ) {
 			return $cached;
 		}
 
-		$sites = ( new \Amnesty\Core_Site_List() )->get_sites();
-		wp_cache_set( 'amnesty_get_sites', $sites );
+		$sites = ( new \Amnesty\Core_Site_List( $public_only ) )->get_sites();
+		wp_cache_set( $cache_key, $sites );
 
 		if ( ! $filter ) {
 			return $sites;

--- a/wp-content/themes/humanity-theme/patterns/search-results.php
+++ b/wp-content/themes/humanity-theme/patterns/search-results.php
@@ -1,48 +1,264 @@
 <?php
 
 /**
- * Title: Search results pattern
+ * Title: Search Results pattern
  * Description: Search results pattern for the theme
  * Slug: amnesty/search-results
  * Inserter: no
  */
 
 $location_slug = get_option( 'amnesty_location_slug' ) ?: 'location';
+$search_object = amnesty_get_searchpage_query_object();
 
 // add filter to limit the post terms results for search
 add_filter( 'get_the_terms', 'amnesty_limit_post_terms_results_for_search' );
 
+$found_posts     = absint( $search_object->get_wp_query()->found_posts );
+$found_posts_fmt = number_format_i18n( $found_posts );
+$current_sort    = get_query_var( 'sort' ) ?: ( $GLOBALS['wp']->query_vars['sort'] ?? '' );
+$available_sorts = amnesty_valid_sort_parameters();
+
+/* translators: Singular/Plural number of posts. */
+$results = sprintf( _n( '%s result', '%s results', $found_posts, 'amnesty' ), $found_posts_fmt );
+
+if ( is_search() && get_search_query() ) {
+	/* translators: 1: number of results for search query, 2: don't translate (dynamic search term) */
+	$results = sprintf( _n( "%1\$s result for '%2\$s'", "%1\$s results for '%2\$s'", $found_posts, 'amnesty' ), $found_posts_fmt, get_search_query() );
+}
+
+$results = apply_filters( 'amnesty_search_results_title', $results, $found_posts, get_search_query() );
+
+/* translators: [front] https://www.amnesty.org/en/latest/ Previous post navigation label */
+$previous_link = get_previous_posts_link( '<span class="icon"></span><span>' . __( 'Previous', 'amnesty' ) . '</span>' );
+$next_link     = get_next_posts_link(
+	/* translators: [front] https://www.amnesty.org/en/latest/ Next post navigation label */
+	'<span class="icon"></span><span>' . __( 'Next', 'amnesty' ) . '</span>',
+	$search_object->get_wp_query()->max_num_pages,
+);
+
+$page_numbers = amnesty_paginate_links(
+	[
+		'mid_size'  => 1,
+		'prev_next' => false,
+		'type'      => 'array',
+		'total'     => $search_object->get_wp_query()->max_num_pages,
+	]
+);
+
+$has_term = function ( string $taxonomy = 'category' ): bool {
+	switch_to_blog( get_post()->blog_id );
+	$term = amnesty_get_a_post_term( get_the_ID(), $taxonomy );
+	restore_current_blog();
+
+	return (bool) $term;
+};
+
+$term_link = function ( string $taxonomy = 'category' ): string {
+	switch_to_blog( get_post()->blog_id );
+	$term = amnesty_get_a_post_term( get_the_ID(), $taxonomy );
+	restore_current_blog();
+
+	$switch = isset( get_post()->blog_id ) && absint( get_post()->blog_id ) !== get_current_blog_id();
+
+	return $term ? amnesty_cross_blog_term_link( $term, $switch ) : '';
+};
+
+$term_name = function ( string $taxonomy = 'category' ): ?string {
+	switch_to_blog( get_post()->blog_id );
+	$term = amnesty_get_a_post_term( get_the_ID(), $taxonomy );
+	restore_current_blog();
+
+	return $term->name;
+};
+
 ?>
-<!-- wp:query {"inherit":true} -->
-<div class="wp-block-query">
+
+<!-- wp:group {"tagName":"div"} -->
+<div class="wp-block-group">
 	<!-- wp:group {"tagName":"div","className":"section section--tinted search-results"} -->
 	<div class="wp-block-group section section--tinted search-results">
-		<!-- wp:amnesty-core/archive-header /-->
-		<!-- wp:post-template {"layout":{"type":"constrained","justifyContent":"left"}} -->
+		<!-- wp:group {"tagName":"header","className":"postlist-header"} -->
+		<header class="wp-block-group postlist-header">
+			<!-- wp:heading {"className":"postlist-headerTitle"} -->
+			<h2 class="wp-block-heading postlist-headerTitle">
+				<?php echo esc_html( $results ); ?>
+			</h2>
+			<!-- /wp:heading -->
+			<?php
 
-		<!-- wp:group {"tagName":"article","className":"post post--result"} -->
-		<article class="wp-block-group post post--result">
-			<!-- wp:group {"tagName":"div","className":"post-terms","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-			<div class="wp-block-group post-terms">
-				<!-- wp:post-terms {"term":"category","className":"post-category"} /-->
-				<!-- wp:post-terms {"term":"<?php echo esc_attr( $location_slug ); ?>","className":"post-location"} /-->
-				<!-- wp:post-terms {"term":"topic","className":"post-topic"} /-->
-			</div>
-			<!-- /wp:group -->
-			<!-- wp:post-title {"isLink":true,"className":"post-title"} /-->
-			<!-- wp:post-excerpt {"className":"post-excerpt"} /-->
-			<!-- wp:post-date {"className":"post-byline"} /-->
-		</article>
+			// goes haywire in admin
+			if ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && ! REST_REQUEST ) ) {
+				$current_sort_option = $available_sorts[ $current_sort ] ?? null;
+
+				// move current sort to the top of the list
+				if ( $current_sort_option ) {
+					unset( $available_sorts[ $current_sort ] );
+					$available_sorts = [ $current_sort => $current_sort_option ] + $available_sorts;
+				}
+
+				amnesty_render_custom_select(
+					[
+						'label'      => __( 'Sort by', 'amnesty' ),
+						'show_label' => true,
+						'name'       => 'sort',
+						'is_form'    => true,
+						'multiple'   => false,
+						'options'    => $available_sorts,
+					]
+				);
+			}
+
+			?>
+		</header>
 		<!-- /wp:group -->
 
-		<!-- /wp:post-template -->
+
+	<?php if ( $search_object->get_wp_query()->have_posts() ) : ?>
+
+		<!-- wp:list {"className":"wp-block-post-template is-layout-constrained"} -->
+		<ul class="wp-block-list wp-block-post-template is-layout-constrained">
+
+		<?php while ( $search_object->get_wp_query()->have_posts() ) : ?>
+			<?php $search_object->get_wp_query()->the_post(); ?>
+
+			<!-- wp:list-item {"className":"wp-block-post"} -->
+			<li class="wp-block-list-item wp-block-post">
+				<!-- wp:group {"tagName":"article","className":"post post--result"} -->
+				<article class="wp-block-group post post--result">
+					<!-- wp:group {"tagName":"div","className":"post-terms","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group post-terms">
+
+					<?php if ( $has_term() ) : ?>
+						<!-- wp:group {"tagName":"div","className":"taxonomy-category post-category wp-block-post-terms"} -->
+						<div class="wp-block-group taxonomy-category post-category wp-block-post-terms">
+							<!-- wp:paragraph -->
+							<p class="wp-block-paragraph">
+								<a href="<?php echo esc_url( $term_link() ); ?>" rel="tag">
+									<?php echo esc_html( $term_name() ); ?>
+								</a>
+							</p>
+							<!-- /wp:paragraph -->
+						</div>
+						<!-- /wp:group -->
+					<?php endif; ?>
+
+					<?php if ( $has_term( $location_slug ) ) : ?>
+						<!-- wp:group {"tagName":"div","className":"taxonomy-<?php echo esc_attr( $location_slug ); ?> post-<?php echo esc_attr( $location_slug ); ?> wp-block-post-terms"} -->
+						<div class="wp-block-group taxonomy-<?php echo esc_attr( $location_slug ); ?> post-<?php echo esc_attr( $location_slug ); ?> wp-block-post-terms">
+							<!-- wp:paragraph -->
+							<p class="wp-block-paragraph">
+								<a href="<?php echo esc_url( $term_link( $location_slug ) ); ?>" rel="tag">
+									<?php echo esc_html( $term_name( $location_slug ) ); ?>
+								</a>
+							</p>
+							<!-- /wp:paragraph -->
+						</div>
+						<!-- /wp:group -->
+					<?php endif; ?>
+
+					<?php if ( $has_term( 'topic' ) ) : ?>
+						<!-- wp:group {"tagName":"div","className":"taxonomy-topic post-topic wp-block-post-terms"} -->
+						<div class="wp-block-group taxonomy-topic post-topic wp-block-post-terms">
+							<!-- wp:paragraph -->
+							<p class="wp-block-paragraph">
+								<a href="<?php echo esc_url( $term_link( 'topic' ) ); ?>" rel="tag">
+									<?php echo esc_html( $term_name( 'topic' ) ); ?>
+								</a>
+							</p>
+							<!-- /wp:paragraph -->
+						</div>
+						<!-- /wp:group -->
+					<?php endif; ?>
+
+					</div>
+					<!-- /wp:group -->
+					<!-- wp:heading {"level":2,"className":"post-title wp-block-post-title"} -->
+					<h2 class="wp-block-heading post-title wp-block-post-title">
+						<a href="<?php echo esc_url( get_blog_permalink( get_post()->blog_id, get_the_ID() ) ); ?>" target="_self"><?php the_title(); ?></a>
+					</h2>
+					<!-- /wp:heading -->
+					<!-- wp:group {"tagName":"div","className":"post-excerpt wp-block-post-excerpt"} -->
+					<div class="wp-block-group post-excerpt wp-block-post-excerpt">
+						<!-- wp:paragraph {"className":"wp-block-post-excerpt__excerpt"} -->
+						<p class="wp-block-paragraph wp-block-post-excerpt__excerpt"><?php echo wp_kses_post( get_the_excerpt() ); ?></p>
+						<!-- /wp:paragraph -->
+					</div>
+					<!-- /wp:group -->
+					<!-- wp:group -->
+					<div class="wp-block-group post-byline wp-block-post-date">
+						<!-- wp:paragraph -->
+						<p class="wp-block-paragraph">
+							<time datetime="<?php echo esc_attr( get_the_modified_date( 'c' ) ); ?>"><?php echo esc_html( get_the_modified_date() ); ?></time>
+						</p>
+						<!-- /wp:paragraph -->
+					</div>
+					<!-- /wp:group -->
+				</article>
+				<!-- /wp:group -->
+			</li>
+			<!-- /wp:list-item -->
+
+		<?php endwhile; ?>
+
+		</ul>
+		<!-- /wp:list -->
+
+	<?php endif; ?>
+
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:query-pagination {"align":"center","className":"section section--small","paginationArrow":"none","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
-		<!-- wp:query-pagination-previous {"label":"<?php echo esc_html( __( 'Previous', 'amnesty' ) ); ?>"} /-->
-		<!-- wp:query-pagination-numbers {"midSize":1,"className":"page-numbers"} /-->
-		<!-- wp:query-pagination-next {"label":"<?php echo esc_html( __( 'Next', 'amnesty' ) ); ?>"} /-->
-	<!-- /wp:query-pagination -->
+<?php if ( $search_object->get_wp_query()->have_posts() ) : ?>
+
+	<!-- wp:group {"tagName":"section","className":"section section--small post-pagination"} -->
+	<section class="wp-block-group section section--small post-pagination">
+		<!-- wp:group {"tagName":"nav","className":"post-paginationContainer","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+		<nav class="wp-block-group post-paginationContainer">
+			<!-- wp:group {"tagName":"div","className":"post-paginationLink post-paginationPrevious"} -->
+			<div class="wp-block-group post-paginationLink post-paginationPrevious">
+			<?php if ( $previous_link && ! is_admin() ) : ?>
+				<?php echo wp_kses_post( $previous_link ); ?>
+			<?php else : ?>
+				<!-- wp:buttons -->
+				<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-pagination is-disabled"} -->
+				<div class="wp-block-button is-style-pagination is-disabled"><a class="wp-block-button__link wp-element-button"><span class="icon"></span>
+				<span><?php /* translators: [front] https://www.amnesty.org/en/latest/ */ esc_html_e( 'Previous', 'amnesty' ); ?></span></a></div>
+				<!-- /wp:button --></div>
+				<!-- /wp:buttons -->
+			<?php endif; ?>
+			</div>
+			<!-- /wp:group -->
+			<!-- wp:list {"className":"page-numbers"} -->
+			<ul class="wp-block-list page-numbers">
+			<?php foreach ( $page_numbers as $number ) : ?>
+				<!-- wp:list-item -->
+				<li class="wp-block-list-item"><?php echo wp_kses_post( $number ); ?></li>
+				<!-- /wp:list-item -->
+			<?php endforeach; ?>
+			</ul>
+			<!-- /wp:list -->
+			<!-- wp:group {"tagName":"div","className":"post-paginationLink post-paginationNext"} -->
+			<div class="wp-block-group post-paginationLink post-paginationNext">
+			<?php if ( $next_link && ! is_admin() ) : ?>
+				<?php echo wp_kses_post( $next_link ); ?>
+			<?php else : ?>
+				<!-- wp:buttons -->
+				<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-pagination is-disabled"} -->
+				<div class="wp-block-button is-style-pagination is-disabled"><a class="wp-block-button__link wp-element-button"><span><?php /* translators: [front] https://www.amnesty.org/en/latest/ */ esc_html_e( 'Next', 'amnesty' ); ?></span>
+				<span class="icon"></span></a></div>
+				<!-- /wp:button --></div>
+				<!-- /wp:buttons -->
+			<?php endif; ?>
+			</div>
+			<!-- /wp:group -->
+		</nav>
+		<!-- /wp:group -->
+	</section>
+	<!-- /wp:group -->
+
+<?php endif; ?>
+
 </div>
-<!-- /wp:query -->
+<!-- /wp:group -->
+
+<?php wp_reset_postdata(); ?>

--- a/wp-content/themes/humanity-theme/patterns/search.php
+++ b/wp-content/themes/humanity-theme/patterns/search.php
@@ -8,63 +8,257 @@
  */
 
 $location_slug = get_option( 'amnesty_location_slug' ) ?: 'location';
-$search_object = amnesty_get_searchpage_query_object( false );
-
-$block_args = [
-	'queryId' => 0,
-	'query'   => $search_object->get_block_vars(),
-];
-
-// custom queries sometimes break retrieval in the site editor
-if ( is_admin() ) {
-	$block_args['query'] = [];
-}
-
-add_filter( 'query_loop_block_query_vars', fn () => $search_object->get_query_vars() );
-
-if ( amnesty_get_query_var( 'qyear' ) ) {
-	add_filter( 'query_loop_block_query_vars', fn ( array $vars ): array => $vars + [ 'year' => absint( amnesty_get_query_var( 'qyear' ) ) ] );
-}
-
-if ( amnesty_get_query_var( 'qmonth' ) ) {
-	add_filter( 'query_loop_block_query_vars', fn ( array $vars ): array => $vars + [ 'monthnum' => absint( amnesty_get_query_var( 'qmonth' ) ) ] );
-}
+$search_object = amnesty_get_searchpage_query_object();
 
 // add filter to limit the post terms results for search
 add_filter( 'get_the_terms', 'amnesty_limit_post_terms_results_for_search' );
 
+$found_posts     = absint( $search_object->get_wp_query()->found_posts );
+$found_posts_fmt = number_format_i18n( $found_posts );
+$current_sort    = get_query_var( 'sort' ) ?: ( $GLOBALS['wp']->query_vars['sort'] ?? '' );
+$available_sorts = amnesty_valid_sort_parameters();
+
+/* translators: Singular/Plural number of posts. */
+$results = sprintf( _n( '%s result', '%s results', $found_posts, 'amnesty' ), $found_posts_fmt );
+
+if ( is_search() && get_search_query() ) {
+	/* translators: 1: number of results for search query, 2: don't translate (dynamic search term) */
+	$results = sprintf( _n( "%1\$s result for '%2\$s'", "%1\$s results for '%2\$s'", $found_posts, 'amnesty' ), $found_posts_fmt, get_search_query() );
+}
+
+$results = apply_filters( 'amnesty_search_results_title', $results, $found_posts, get_search_query() );
+
+/* translators: [front] https://www.amnesty.org/en/latest/ Previous post navigation label */
+$previous_link = get_previous_posts_link( '<span class="icon"></span><span>' . __( 'Previous', 'amnesty' ) . '</span>' );
+$next_link     = get_next_posts_link(
+	/* translators: [front] https://www.amnesty.org/en/latest/ Next post navigation label */
+	'<span class="icon"></span><span>' . __( 'Next', 'amnesty' ) . '</span>',
+	$search_object->get_wp_query()->max_num_pages,
+);
+
+$page_numbers = amnesty_paginate_links(
+	[
+		'mid_size'  => 1,
+		'prev_next' => false,
+		'type'      => 'array',
+		'total'     => $search_object->get_wp_query()->max_num_pages,
+	]
+);
+
+$has_term = function ( string $taxonomy = 'category' ): bool {
+	switch_to_blog( get_post()->blog_id );
+	$term = amnesty_get_a_post_term( get_the_ID(), $taxonomy );
+	restore_current_blog();
+
+	return (bool) $term;
+};
+
+$term_link = function ( string $taxonomy = 'category' ): string {
+	switch_to_blog( get_post()->blog_id );
+	$term = amnesty_get_a_post_term( get_the_ID(), $taxonomy );
+	restore_current_blog();
+
+	$switch = isset( get_post()->blog_id ) && absint( get_post()->blog_id ) !== get_current_blog_id();
+
+	return $term ? amnesty_cross_blog_term_link( $term, $switch ) : '';
+};
+
+$term_name = function ( string $taxonomy = 'category' ): ?string {
+	switch_to_blog( get_post()->blog_id );
+	$term = amnesty_get_a_post_term( get_the_ID(), $taxonomy );
+	restore_current_blog();
+
+	return $term->name;
+};
+
 ?>
 
-<!-- wp:query <?php echo wp_kses_data( wp_json_encode( $block_args ) ); ?> -->
-<div class="wp-block-query">
+<!-- wp:group {"tagName":"div"} -->
+<div class="wp-block-group">
 	<!-- wp:group {"tagName":"div","className":"section section--tinted search-results"} -->
 	<div class="wp-block-group section section--tinted search-results">
-		<!-- wp:amnesty-core/search-header /-->
-		<!-- wp:post-template {"layout":{"type":"constrained","justifyContent":"left"}} -->
+		<!-- wp:group {"tagName":"header","className":"postlist-header"} -->
+		<header class="wp-block-group postlist-header">
+			<!-- wp:heading {"className":"postlist-headerTitle"} -->
+			<h2 class="wp-block-heading postlist-headerTitle">
+				<?php echo esc_html( $results ); ?>
+			</h2>
+			<!-- /wp:heading -->
+			<?php
 
-		<!-- wp:group {"tagName":"article","className":"post post--result"} -->
-		<article class="wp-block-group post post--result">
-			<!-- wp:group {"tagName":"div","className":"post-terms","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-			<div class="wp-block-group post-terms">
-				<!-- wp:post-terms {"term":"category","className":"post-category"} /-->
-				<!-- wp:post-terms {"term":"<?php echo esc_attr( $location_slug ); ?>","className":"post-location"} /-->
-				<!-- wp:post-terms {"term":"topic","className":"post-topic"} /-->
-			</div>
-			<!-- /wp:group -->
-			<!-- wp:post-title {"isLink":true,"className":"post-title"} /-->
-			<!-- wp:post-excerpt {"className":"post-excerpt"} /-->
-			<!-- wp:post-date {"className":"post-byline"} /-->
-		</article>
+			// goes haywire in admin
+			if ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && ! REST_REQUEST ) ) {
+				$current_sort_option = $available_sorts[ $current_sort ] ?? null;
+
+				// move current sort to the top of the list
+				if ( $current_sort_option ) {
+					unset( $available_sorts[ $current_sort ] );
+					$available_sorts = [ $current_sort => $current_sort_option ] + $available_sorts;
+				}
+
+				amnesty_render_custom_select(
+					[
+						'label'      => __( 'Sort by', 'amnesty' ),
+						'show_label' => true,
+						'name'       => 'sort',
+						'is_form'    => true,
+						'multiple'   => false,
+						'options'    => $available_sorts,
+					]
+				);
+			}
+
+			?>
+		</header>
 		<!-- /wp:group -->
 
-		<!-- /wp:post-template -->
+
+	<?php if ( $search_object->get_wp_query()->have_posts() ) : ?>
+
+		<!-- wp:list {"className":"wp-block-post-template is-layout-constrained"} -->
+		<ul class="wp-block-list wp-block-post-template is-layout-constrained">
+
+		<?php while ( $search_object->get_wp_query()->have_posts() ) : ?>
+			<?php $search_object->get_wp_query()->the_post(); ?>
+
+			<!-- wp:list-item {"className":"wp-block-post"} -->
+			<li class="wp-block-list-item wp-block-post">
+				<!-- wp:group {"tagName":"article","className":"post post--result"} -->
+				<article class="wp-block-group post post--result">
+					<!-- wp:group {"tagName":"div","className":"post-terms","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+					<div class="wp-block-group post-terms">
+
+					<?php if ( $has_term() ) : ?>
+						<!-- wp:group {"tagName":"div","className":"taxonomy-category post-category wp-block-post-terms"} -->
+						<div class="wp-block-group taxonomy-category post-category wp-block-post-terms">
+							<!-- wp:paragraph -->
+							<p class="wp-block-paragraph">
+								<a href="<?php echo esc_url( $term_link() ); ?>" rel="tag">
+									<?php echo esc_html( $term_name() ); ?>
+								</a>
+							</p>
+							<!-- /wp:paragraph -->
+						</div>
+						<!-- /wp:group -->
+					<?php endif; ?>
+
+					<?php if ( $has_term( $location_slug ) ) : ?>
+						<!-- wp:group {"tagName":"div","className":"taxonomy-<?php echo esc_attr( $location_slug ); ?> post-<?php echo esc_attr( $location_slug ); ?> wp-block-post-terms"} -->
+						<div class="wp-block-group taxonomy-<?php echo esc_attr( $location_slug ); ?> post-<?php echo esc_attr( $location_slug ); ?> wp-block-post-terms">
+							<!-- wp:paragraph -->
+							<p class="wp-block-paragraph">
+								<a href="<?php echo esc_url( $term_link( $location_slug ) ); ?>" rel="tag">
+									<?php echo esc_html( $term_name( $location_slug ) ); ?>
+								</a>
+							</p>
+							<!-- /wp:paragraph -->
+						</div>
+						<!-- /wp:group -->
+					<?php endif; ?>
+
+					<?php if ( $has_term( 'topic' ) ) : ?>
+						<!-- wp:group {"tagName":"div","className":"taxonomy-topic post-topic wp-block-post-terms"} -->
+						<div class="wp-block-group taxonomy-topic post-topic wp-block-post-terms">
+							<!-- wp:paragraph -->
+							<p class="wp-block-paragraph">
+								<a href="<?php echo esc_url( $term_link( 'topic' ) ); ?>" rel="tag">
+									<?php echo esc_html( $term_name( 'topic' ) ); ?>
+								</a>
+							</p>
+							<!-- /wp:paragraph -->
+						</div>
+						<!-- /wp:group -->
+					<?php endif; ?>
+
+					</div>
+					<!-- /wp:group -->
+					<!-- wp:heading {"level":2,"className":"post-title wp-block-post-title"} -->
+					<h2 class="wp-block-heading post-title wp-block-post-title">
+						<a href="<?php echo esc_url( get_blog_permalink( get_post()->blog_id, get_the_ID() ) ); ?>" target="_self"><?php the_title(); ?></a>
+					</h2>
+					<!-- /wp:heading -->
+					<!-- wp:group {"tagName":"div","className":"post-excerpt wp-block-post-excerpt"} -->
+					<div class="wp-block-group post-excerpt wp-block-post-excerpt">
+						<!-- wp:paragraph {"className":"wp-block-post-excerpt__excerpt"} -->
+						<p class="wp-block-paragraph wp-block-post-excerpt__excerpt"><?php echo wp_kses_post( get_the_excerpt() ); ?></p>
+						<!-- /wp:paragraph -->
+					</div>
+					<!-- /wp:group -->
+					<!-- wp:group -->
+					<div class="wp-block-group post-byline wp-block-post-date">
+						<!-- wp:paragraph -->
+						<p class="wp-block-paragraph">
+							<time datetime="<?php echo esc_attr( get_the_modified_date( 'c' ) ); ?>"><?php echo esc_html( get_the_modified_date() ); ?></time>
+						</p>
+						<!-- /wp:paragraph -->
+					</div>
+					<!-- /wp:group -->
+				</article>
+				<!-- /wp:group -->
+			</li>
+			<!-- /wp:list-item -->
+
+		<?php endwhile; ?>
+
+		</ul>
+		<!-- /wp:list -->
+
+	<?php endif; ?>
+
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:query-pagination {"align":"center","className":"section section--small","paginationArrow":"none","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
-		<!-- wp:query-pagination-previous {"label":"<?php echo esc_html( __( 'Previous', 'amnesty' ) ); ?>","paged":<?php echo absint( get_query_var( 'paged' ) ?: 1 ); ?>} /-->
-		<!-- wp:query-pagination-numbers {"midSize":1,"paged":<?php echo absint( get_query_var( 'paged' ) ?: 1 ); ?>,"pretty":true,"className":"page-numbers"} /-->
-		<!-- wp:query-pagination-next {"label":"<?php echo esc_html( __( 'Next', 'amnesty' ) ); ?>","paged":<?php echo absint( get_query_var( 'paged' ) ?: 1 ); ?>} /-->
-	<!-- /wp:query-pagination -->
+<?php if ( $search_object->get_wp_query()->have_posts() ) : ?>
+
+	<!-- wp:group {"tagName":"section","className":"section section--small post-pagination"} -->
+	<section class="wp-block-group section section--small post-pagination">
+		<!-- wp:group {"tagName":"nav","className":"post-paginationContainer","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+		<nav class="wp-block-group post-paginationContainer">
+			<!-- wp:group {"tagName":"div","className":"post-paginationLink post-paginationPrevious"} -->
+			<div class="wp-block-group post-paginationLink post-paginationPrevious">
+			<?php if ( $previous_link && ! is_admin() ) : ?>
+				<?php echo wp_kses_post( $previous_link ); ?>
+			<?php else : ?>
+				<!-- wp:buttons -->
+				<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-pagination is-disabled"} -->
+				<div class="wp-block-button is-style-pagination is-disabled"><a class="wp-block-button__link wp-element-button"><span class="icon"></span>
+				<span><?php /* translators: [front] https://www.amnesty.org/en/latest/ */ esc_html_e( 'Previous', 'amnesty' ); ?></span></a></div>
+				<!-- /wp:button --></div>
+				<!-- /wp:buttons -->
+			<?php endif; ?>
+			</div>
+			<!-- /wp:group -->
+			<!-- wp:list {"className":"page-numbers"} -->
+			<ul class="wp-block-list page-numbers">
+			<?php foreach ( $page_numbers as $number ) : ?>
+				<!-- wp:list-item -->
+				<li class="wp-block-list-item"><?php echo wp_kses_post( $number ); ?></li>
+				<!-- /wp:list-item -->
+			<?php endforeach; ?>
+			</ul>
+			<!-- /wp:list -->
+			<!-- wp:group {"tagName":"div","className":"post-paginationLink post-paginationNext"} -->
+			<div class="wp-block-group post-paginationLink post-paginationNext">
+			<?php if ( $next_link && ! is_admin() ) : ?>
+				<?php echo wp_kses_post( $next_link ); ?>
+			<?php else : ?>
+				<!-- wp:buttons -->
+				<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-pagination is-disabled"} -->
+				<div class="wp-block-button is-style-pagination is-disabled"><a class="wp-block-button__link wp-element-button"><span><?php /* translators: [front] https://www.amnesty.org/en/latest/ */ esc_html_e( 'Next', 'amnesty' ); ?></span>
+				<span class="icon"></span></a></div>
+				<!-- /wp:button --></div>
+				<!-- /wp:buttons -->
+			<?php endif; ?>
+			</div>
+			<!-- /wp:group -->
+		</nav>
+		<!-- /wp:group -->
+	</section>
+	<!-- /wp:group -->
+
+<?php endif; ?>
+
 </div>
-<!-- /wp:query -->
+<!-- /wp:group -->
+
+<?php wp_reset_postdata(); ?>


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/2994

There was loads of stuff that inexplicably stopped working with the addition of new sites.
With the weird way blocks are processed by WP, it was difficult to repair without hacks.
So we've unfortunately binned off some blocks, including the query loop stuff.
Should really split some of this out into patterns.

Search result terms look a little strange in the editor, but they do function, at least.