### PR TITLE
Fix typo in pattern slug

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/archive-heading.php
+++ b/wp-content/themes/humanity-theme/patterns/archive-heading.php
@@ -3,7 +3,7 @@
 /**
  * Title: Archive filters
  * Description: Outputs filters for post type archive pages
- * Slug: amnesty/archive-filters
+ * Slug: amnesty/archive-heading
  * Inserter: no
  */
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/621

**Steps to test**:
1. visit `latest/news/` / `latest/research/` / etc.
2. the archive heading + description should render
