### PR TITLE
Fix incorrect date timezone output in PDF pattern

### DIFF
--- a/wp-content/themes/humanity-theme/patterns/attachment-published-date.php
+++ b/wp-content/themes/humanity-theme/patterns/attachment-published-date.php
@@ -34,7 +34,8 @@ do_action( 'amnesty_before_published_date' );
 
 try {
 	$datetime = new DateTime( $post->post_date_gmt, new DateTimeZone( 'GMT' ) );
-	$format   = get_option( 'date_format' );
+	$datetime->setTimezone( wp_timezone() );
+	$format = get_option( 'date_format' );
 } catch ( DateMalformedStringException $e ) {
 	return;
 }


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/sharepoint-runner/issues/66

**Steps to test**:
1. view a document that was uploaded at midnight BST
2. the published date in the metadata area should show the correct date
