### PR TITLE
Only allow text decoration on text anchors

### DIFF
--- a/private/src/styles/base/_links.scss
+++ b/private/src/styles/base/_links.scss
@@ -11,6 +11,6 @@ a {
   text-decoration: underline;
 }
 
-.single main a:not(.btn) {
+.single main p a:not(.btn) {
   text-decoration: underline;
 }


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/611

**Steps to test**:
1. view a post single
2. check that links within the post content are underlined
3. check that tags, back buttons, sidebar items, etc. are not underlined

**Considerations**:
- Accessibility
  - Regions (semantic HTML tags, e.g. `<section>`; [landmarks](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#landmark_roles); etc.)
  - Screen reader compatibility, labels ([`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label), [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby), etc.)
  - Keyboard navigability
- Localisation
- RTL
