### PR TITLE
Fix Post List object selection for non-default post type

### DIFF
--- a/private/src/scripts/editor/blocks/post-list/PostsWrapper.jsx
+++ b/private/src/scripts/editor/blocks/post-list/PostsWrapper.jsx
@@ -315,6 +315,7 @@ const PostsWrapper = createHigherOrderComponent((BlockEdit) => {
                 preview={this.state.preview}
                 style={attributes.style}
                 prefix={this.state.keyPrefix}
+                postType={attributes.postType}
                 overrideTypes={postTypeOveride}
                 showAuthor={attributes.displayAuthor}
                 showPostDate={attributes.displayPostDate}

--- a/private/src/scripts/editor/blocks/post-list/components/DisplaySelect.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/DisplaySelect.jsx
@@ -72,7 +72,7 @@ class DisplaySelect extends Component {
       pagesTotal: {},
       paging: false,
       posts: [],
-      type: 'post',
+      type: this.props.postType || 'post',
       types: [],
       taxonomies: [],
       taxonomy: '',
@@ -91,12 +91,11 @@ class DisplaySelect extends Component {
       initialLoading: true,
     });
 
-    let defaultType;
+    let defaultType = this.props.postType;
 
-    if (this.props.overrideTypes) {
+    if (this.props.overrideTypes && !this.props.overrideTypes.includes(defaultType)) {
       Object.keys(this.props.overrideTypes).map((key, index) => {
         if (index === 0) {
-          // this.setState({ type: this.props.overrideTypes[key].rest_base });
           defaultType = key;
         }
         return key;
@@ -105,7 +104,7 @@ class DisplaySelect extends Component {
       this.setState(
         {
           types: this.props.overrideTypes,
-          type: defaultType !== null ? defaultType : 'post',
+          type: defaultType || 'post',
         },
         () => {
           this.retrieveSelectedPosts().then(() => {
@@ -122,8 +121,15 @@ class DisplaySelect extends Component {
       api.getPostTypes().then((data) => {
         const types = data;
         delete types.attachment;
-        delete types.wp_block;
+        delete types.nav_menu_item;
         delete types.sidebar;
+        delete types.wp_block;
+        delete types.wp_font_face;
+        delete types.wp_font_family;
+        delete types.wp_global_styles;
+        delete types.wp_navigation;
+        delete types.wp_template;
+        delete types.wp_template_part;
 
         this.setState(
           {
@@ -159,6 +165,7 @@ class DisplaySelect extends Component {
   getPosts = (args = {}) => {
     const pageKey = this.state.filter ? false : this.state.type;
     const { get } = lodash;
+
     const defaultArgs = {
       per_page: 10,
       type: this.state.type,
@@ -278,7 +285,7 @@ class DisplaySelect extends Component {
     const selected = this.props.selectedPosts;
     const { types } = this.state;
 
-    if (!selected.length > 0) {
+    if (!selected.length) {
       // return a fake promise that auto resolves.
       // this possibly needs refactoring.
       // eslint-disable-next-line no-promise-executor-return
@@ -347,6 +354,7 @@ class DisplaySelect extends Component {
    * @param string type - comes from the event object target.
    */
   handlePostTypeChange = ({ target: { value: type = '' } = {} } = {}) => {
+    this.props.setAttributes({ postType: type });
     this.setState({ type, loading: true }, () => {
       // fetch posts, then set loading = false
       this.getPosts().then(() => this.setState({ loading: false }));

--- a/private/src/scripts/editor/blocks/post-list/components/post-selector/Post.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/post-selector/Post.jsx
@@ -1,4 +1,11 @@
 import { Draggable } from 'react-beautiful-dnd';
+
+function decodeEntities(string) {
+  const txt = document.createElement('textarea');
+  txt.innerHTML = string;
+  return txt.value;
+}
+
 /**
  * Post Component.
  *
@@ -36,7 +43,7 @@ export const Post = ({
         >
           <figure className="post-figure" style={style}></figure>
           <div className="post-body">
-            <h3 className="post-title">{postTitle}</h3>
+            <h3 className="post-title">{decodeEntities(postTitle)}</h3>
           </div>
           {icon && <button onClick={() => clickHandler(postId)}>{icon}</button>}
         </article>

--- a/private/src/scripts/editor/blocks/post-list/components/post-selector/PostSelector.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/post-selector/PostSelector.jsx
@@ -35,10 +35,15 @@ const PostSelector = (props) => {
             </label>
           </div>
           <div className="filter">
-            <label htmlFor="options">
+            <label htmlFor="postList-postType">
               {/* translators: [admin] */ __('Post Type:', 'amnesty')}{' '}
             </label>
-            <select name="options" id="options" onChange={props.handlePostTypeChange}>
+            <select
+              id="postList-postType"
+              name="options"
+              onChange={props.handlePostTypeChange}
+              value={props.state.type}
+            >
               {props.state.types.length < 1 ? (
                 // translators: [admin]
                 <option value="">{__('Loading…', 'amnesty')}</option>
@@ -50,60 +55,44 @@ const PostSelector = (props) => {
                 ))
               )}
             </select>
-            <label htmlFor="options">
+            <label htmlFor="postList-taxonomy">
               {/* translators: [admin] */ __('Taxonomy:', 'amnesty')}{' '}
             </label>
-            <select name="options" id="options" onChange={props.handleTaxonomyChange}>
+            <select name="options" id="postList-taxonomy" onChange={props.handleTaxonomyChange}>
               {props.state.taxonomies.length < 1 ? (
                 // translators: [admin]
                 <option value="">{__('Loading…', 'amnesty')}</option>
               ) : (
-                Object.keys(props.state.taxonomies).map((key, index) => {
-                  if (index === 0) {
-                    return (
-                      <>
-                        <option value="">
-                          {/* translators: [admin] */ __('Select Taxonomy', 'amnesty')}
-                        </option>
-                        <option key={key} value={props.state.taxonomies[key].rest_base}>
-                          {props.state.taxonomies[key].name}
-                        </option>
-                      </>
-                    );
-                  }
-                  return (
+                <>
+                  <option value="">
+                    {/* translators: [admin] */ __('Select Taxonomy', 'amnesty')}
+                  </option>
+                  {Object.keys(props.state.taxonomies).map((key) => (
                     <option key={key} value={props.state.taxonomies[key].rest_base}>
                       {props.state.taxonomies[key].name}
                     </option>
-                  );
-                })
+                  ))}
+                </>
               )}
             </select>
-            <label htmlFor="options">{/* translators: [admin] */ __('Terms:', 'amnesty')} </label>
-            <select name="options" id="options" onChange={props.handleTermChange}>
+            <label htmlFor="postList-terms">
+              {/* translators: [admin] */ __('Terms:', 'amnesty')}&nbsp;
+            </label>
+            <select name="options" id="postList-terms" onChange={props.handleTermChange}>
               {props.state.terms.length < 1 ? (
                 // translators: [admin]
                 <option value="">{__('No taxonomy selected', 'amnesty')}</option>
               ) : (
-                Object.keys(props.state.terms).map((key, index) => {
-                  if (index === 0) {
-                    return (
-                      <>
-                        <option value="">
-                          {/* translators: [admin] */ __('Select Term', 'amnesty')}
-                        </option>
-                        <option key={key} value={props.state.terms[key].id}>
-                          {props.state.terms[key].name}
-                        </option>
-                      </>
-                    );
-                  }
-                  return (
+                <>
+                  <option value="">
+                    {/* translators: [admin] */ __('Select Term', 'amnesty')}
+                  </option>
+                  {Object.keys(props.state.terms).map((key) => (
                     <option key={key} value={props.state.terms[key].id}>
                       {props.state.terms[key].name}
                     </option>
-                  );
-                })
+                  ))}
+                </>
               )}
             </select>
           </div>

--- a/private/src/scripts/editor/blocks/post-list/index.jsx
+++ b/private/src/scripts/editor/blocks/post-list/index.jsx
@@ -33,6 +33,10 @@ const blockAttributes = {
   selectedPosts: {
     type: 'array',
   },
+  postType: {
+    type: 'string',
+    default: 'post',
+  },
   taxonomyFilters: {
     type: 'array',
   },


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/466

**Steps to test**:
1. open a new post
2. add a post list
3. select grid style and object selection type
4. select post type: pages
5. add some pages to the list
6. save the post
7. reload the editor
8. the items should render in the post list
9. click "toggle preview"
10. the post selection LHS should list available pages
11. the post selection RHS should list selected pages
12. the post type select dropdown should show the Pages post type 
