### PR TITLE
Fix Post List output when taxonomy rest base doesn't match the slug

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/post-list/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/post-list/render.php
@@ -321,14 +321,14 @@ if ( ! function_exists( 'amnesty_list_process_taxonomy' ) ) {
 
 		$query = new WP_Query(
 			[
-				'type'           => 'post',
+				'post_type'      => 'post',
 				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_post__not_in
 				'post__not_in'   => [ get_the_ID() ],
 				'posts_per_page' => $amount,
 				'no_found_rows'  => true,
 				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 					[
-						'taxonomy' => $taxonomy,
+						'taxonomy' => amnesty_get_taxonomy_slug_from_rest_base( $taxonomy ),
 						'terms'    => $terms,
 						'field'    => 'term_id',
 					],

--- a/wp-content/themes/humanity-theme/includes/helpers/taxonomies.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/taxonomies.php
@@ -903,3 +903,24 @@ if ( ! function_exists( 'amnesty_limit_post_terms_results_for_search' ) ) {
 		return $terms;
 	}
 }
+
+if ( ! function_exists( 'amnesty_get_taxonomy_slug_from_rest_base' ) ) {
+	/**
+	 * Retrieve a taxonomy slug from its rest base
+	 *
+	 * @param string $base the taxonomy rest base
+	 *
+	 * @return string|null
+	 */
+	function amnesty_get_taxonomy_slug_from_rest_base( string $base ): ?string {
+		$taxonomies = get_taxonomies( output: 'objects' );
+
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( $taxonomy->rest_base === $base ) {
+				return $taxonomy->name;
+			}
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/23

**Steps to test**:
1. add a post
2. insert post list block
3. in the block settings:
   - select style: **grid**
   - type: **taxonomy**
   - taxonomy: **resource type**
   - terms: at least one
4. save
5. preview the post
6. the post list should render correctly on the frontend
