### PR TITLE
Prevent output of Post List tag if it has no text

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/post-list/views/grid-item-meta.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/post-list/views/grid-item-meta.php
@@ -1,12 +1,14 @@
 <?php
 
-if ( ! isset( $data['tag'], $data['tag_link'] ) ) {
+$has_data = isset( $data['tag'], $data['tag_link'] ) && (bool) $data['tag'];
+
+if ( ! $has_data ) {
 	return;
 }
 
 $output = esc_html( $data['tag'] );
 
-if ( isset( $data['tag_link'] ) && (bool) $data['tag_link'] ) {
+if ( (bool) $data['tag_link'] && (bool) $data['tag_link'] ) {
 	$output = sprintf( '<a href="%s" tabindex="0">%s</a>', esc_url( $data['tag_link'] ), esc_html( $data['tag'] ) );
 }
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/597

**Steps to test**:
1. add a post
2. insert a post list block
3. set the style to **grid**
4. set the type to **custom**
5. add a few items
6. input nothing in the tag field for one item
7. input only text in the tag field for one item
8. input only a link in the tag field for one item
9. input both text and a link in the tag field for one item
10. save the post
11. preview the frontend
12. only on items where there is text in the tag field should the tag area be output
