### PR TITLE
Fix issue with type checking on featured image caption data

### DIFF
--- a/private/src/styles/pages/article/_featured-image.scss
+++ b/private/src/styles/pages/article/_featured-image.scss
@@ -6,3 +6,7 @@
   max-width: 100%;
   height: auto;
 }
+
+.article-figure .image-metadata {
+  width: 100%;
+}

--- a/wp-content/themes/humanity-theme/includes/core-blocks/image/filters.php
+++ b/wp-content/themes/humanity-theme/includes/core-blocks/image/filters.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'amnesty_build_new_image_block_tag' ) ) {
 		$hide_caption   = ( $block['attrs']['hideImageCaption'] ?? true );
 
 		if ( str_contains( $block['attrs']['className'] ?? '', 'article-figure' ) ) {
-			$hide_caption = '1' === get_post_meta( get_the_ID(), '_hide_featured_image_caption', true );
+			$hide_caption = amnesty_validate_boolish( get_post_meta( get_the_ID(), '_hide_featured_image_caption', true ) );
 		}
 
 		$new_image_tag .= $image_obj->metadata( ! $hide_caption, ! $hide_copyright );

--- a/wp-content/themes/humanity-theme/patterns/featured-image.php
+++ b/wp-content/themes/humanity-theme/patterns/featured-image.php
@@ -25,9 +25,10 @@ if ( ! $image_id ) {
 
 $image = new Get_Image_Data( $image_id );
 
+$classname  = 'article-figure is-stretched' . ( $image->credit() ? ' has-caption' : '' );
 $attributes = [
 	'id'              => $image_id,
-	'className'       => 'article-figure is-stretched' . ( $image->credit() ? ' has-caption' : '' ),
+	'className'       => $classname,
 	'sizeSlug'        => 'hero-md',
 	'linkDestination' => 'none',
 ];
@@ -36,7 +37,7 @@ $attributes = [
 <!-- wp:group {"tagName":"div","className":"container container--feature"} -->
 <div class="wp-block-group container container--feature">
 	<!-- wp:image <?php echo wp_kses_data( wp_json_encode( $attributes ) ); ?> -->
-	<figure class="wp-block-image <?php echo esc_attr( $attributes['className'] ); ?>"><img src="<?php echo esc_url( amnesty_get_attachment_image_src( $image_id, 'hero-md' ) ); ?>" alt="" class="wp-image-<?php echo absint( $image_id ); ?>"/></figure>
+	<figure class="wp-block-image <?php echo esc_attr( $classname ); ?>"><img src="<?php echo esc_url( amnesty_get_attachment_image_src( $image_id, 'hero-md' ) ); ?>" alt="" class="wp-image-<?php echo absint( $image_id ); ?>"/></figure>
 	<!-- /wp:image -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/653

**Steps to test**:
1. add a featured image to a post
2. DON'T insert a hero block
3. in appearance options, ensure that the "hide featured image caption" toggle is enabled
4. view the frontend
5. the caption should not be visible
6. the image credit should be visible