### PR TITLE
Flag section for image credit ignore where appropriate

### DIFF
--- a/wp-content/themes/humanity-theme/includes/blocks/section/class-section-block-renderer.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/section/class-section-block-renderer.php
@@ -108,7 +108,7 @@ class Section_Block_Renderer {
 		$this->render_caption();
 		$this->close_section();
 
-		return ob_get_clean();
+		return (string) ob_get_clean();
 	}
 
 	/**
@@ -166,6 +166,7 @@ class Section_Block_Renderer {
 		$classes = classnames(
 			'section',
 			[
+				'aimc-ignore'                              => $this->image->credit(),
 				'section--tinted'                          => 'grey' === $this->attributes['background'],
 				'section--textWhite'                       => 'white' === $this->attributes['textColour'],
 				'section--has-bg-image'                    => (bool) $this->attributes['backgroundImage'],


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/657

**Steps to test**:
1. add a section block
2. set an image that has credit as its background
3. enable the media copyright plugin
4. view the frontend
5. the image should not be replaced by the candle image
