### PR TITLE
Fix missing inputs in search filter dropdowns

### DIFF
--- a/private/src/scripts/modules/search-filters.js
+++ b/private/src/scripts/modules/search-filters.js
@@ -91,8 +91,8 @@ const handleClickEvents = (event) => {
  *
  * @returns {Void}
  */
-const handleChangeEvents = ({ data }) => {
-  const { input } = data;
+const handleChangeEvents = (event) => {
+  const input = event.target;
 
   if (!input) {
     return;

--- a/wp-content/themes/humanity-theme/includes/full-site-editing/blocks/search-form/render.php
+++ b/wp-content/themes/humanity-theme/includes/full-site-editing/blocks/search-form/render.php
@@ -9,9 +9,8 @@ if ( ! function_exists( 'render_search_form_block' ) ) {
 	 * @return string
 	 */
 	function render_search_form_block(): string {
-		spaceless();
+		ob_start();
 		get_template_part( 'partials/search/horizontal-search' );
-
-		return endspaceless( false );
+		return ob_get_clean() ?: '';
 	}
 }

--- a/wp-content/themes/humanity-theme/includes/helpers/frontend.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/frontend.php
@@ -2,6 +2,58 @@
 
 declare( strict_types = 1 );
 
+if ( ! function_exists( 'amnesty_custom_select_kses' ) ) {
+	/**
+	 * Add required tags & attributes to KSES for Custom Select block
+	 *
+	 * @param array<string,array<string,bool>> $tags currently-allowed HTML tags/attributes
+	 *
+	 * @return array<string,array<string,bool>>
+	 */
+	function amnesty_custom_select_kses( array $tags ): array {
+		$attributes = _wp_add_global_attributes( [] );
+
+		$tags = array_merge_recursive(
+			$tags,
+			[
+				'form'  => array_merge(
+					$attributes,
+					[
+						'method'    => true,
+						'action'    => true,
+						'data-info' => true,
+					],
+				),
+				'label' => array_merge(
+					$attributes,
+					[
+						'for'      => true,
+						'tabindex' => true,
+					],
+				),
+				'input' => array_merge(
+					$attributes,
+					[
+						'type'         => true,
+						'name'         => true,
+						'value'        => true,
+						'min'          => true,
+						'max'          => true,
+						'step'         => true,
+						'placeholder'  => true,
+						'disabled'     => true,
+						'required'     => true,
+						'checked'      => true,
+						'autocomplete' => true,
+					],
+				),
+			]
+		);
+
+		return $tags;
+	}
+}
+
 if ( ! function_exists( 'amnesty_render_custom_select' ) ) {
 	/**
 	 * Render an accessible custom select-type element
@@ -71,6 +123,7 @@ if ( ! function_exists( 'amnesty_render_custom_select' ) ) {
 			$block_args['active'] = array_shift( $block_args['active'] );
 		}
 
+		add_filter( 'wp_kses_allowed_html', 'amnesty_custom_select_kses' );
 		echo wp_kses_post(
 			do_blocks(
 				sprintf(
@@ -79,6 +132,7 @@ if ( ! function_exists( 'amnesty_render_custom_select' ) ) {
 				),
 			),
 		);
+		remove_filter( 'wp_kses_allowed_html', 'amnesty_custom_select_kses' );
 	}
 }
 


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/humanity-theme/issues/727

**Steps to test**:
1. visit search
2. click the filters button to expand the list
3. interact with each of the taxonomy filters
4. they should show checkboxes next to the labels
5. clicking an item should select the checkbox, and enable the apply button
6. clicking apply should apply your filters to the list
