### PR TITLE
Fix typo in selector on download block

### DIFF
--- a/private/src/scripts/modules/download-block.js
+++ b/private/src/scripts/modules/download-block.js
@@ -1,5 +1,5 @@
 const setupFormControl = (block) => {
-  const choices = block.querySelector('.checkboxGroup');
+  const choices = block.querySelector('.customSelect');
   const download = block.querySelector('.btn--download');
 
   if (!choices || !download) {


### PR DESCRIPTION
Ref: https://github.com/amnestywebsite/amnesty-wp-theme/issues/3089

**Steps to test**:
1. view an annual report (or any document with many languages)
2. scroll down to the download block
3. select any language other than the first selected language
4. click download
5. the document downloaded should be in the language you selected
