### PR TITLE
[Hotfix] search redirect loop 

### DIFF
--- a/wp-content/themes/humanity-theme/includes/features/search/class-search-filters.php
+++ b/wp-content/themes/humanity-theme/includes/features/search/class-search-filters.php
@@ -133,8 +133,8 @@ class Search_Filters {
 	 * @return string
 	 */
 	public function title_tag( string $title ): string {
-		// we're only targetting search
-		if ( false === strpos( current_url(), amnesty_search_url() ) ) {
+		// we're only targetting search; compare scheme-insensitively, as current_url() forces https
+		if ( false === strpos( set_url_scheme( current_url() ?: '', 'https' ), set_url_scheme( amnesty_search_url(), 'https' ) ) ) {
 			return $title;
 		}
 
@@ -180,8 +180,8 @@ class Search_Filters {
 	 * @return string
 	 */
 	public function results_title( string $title, int $count, string $search ): string {
-		// we're only targetting search
-		if ( false === strpos( current_url(), amnesty_search_url() ) ) {
+		// we're only targetting search; compare scheme-insensitively, as current_url() forces https
+		if ( false === strpos( set_url_scheme( current_url() ?: '', 'https' ), set_url_scheme( amnesty_search_url(), 'https' ) ) ) {
 			return $title;
 		}
 

--- a/wp-content/themes/humanity-theme/includes/helpers/site.php
+++ b/wp-content/themes/humanity-theme/includes/helpers/site.php
@@ -25,7 +25,14 @@ if ( ! function_exists( 'current_url' ) ) {
 		$query = query_string_to_array( $query );
 
 		if ( ! is_multisite() ) {
-			$home = home_url( $path, 'https' );
+			// the search URI override rewrites /search/<term>/ paths to the bare
+			// search URL, which is never the *current* URL; suspend it here
+			$had_filter = remove_filter( 'home_url', 'amnesty_maybe_override_search_uri', 10 );
+			$home       = home_url( $path, 'https' );
+
+			if ( $had_filter ) {
+				add_filter( 'home_url', 'amnesty_maybe_override_search_uri', 10, 2 );
+			}
 
 			return empty( $query ) ? $home : add_query_arg( $query, $home );
 		}

--- a/wp-content/themes/humanity-theme/includes/multisite/helpers.php
+++ b/wp-content/themes/humanity-theme/includes/multisite/helpers.php
@@ -56,6 +56,35 @@ if ( ! function_exists( 'get_blog_post_meta' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_blog_post_term' ) ) {
+	/**
+	 * Multisite-aware amnesty_get_a_post_term
+	 *
+	 * @package Amnesty\Multisite
+	 *
+	 * @param int    $blog_id  the blog id to retrieve post from
+	 * @param int    $post_id  the post to retrieve
+	 * @param string $taxonomy the taxonomy to retrieve a term from
+	 *
+	 * @return WP_Term|null
+	 */
+	function get_blog_post_term( int $blog_id, int $post_id, string $taxonomy = 'category' ): ?WP_Term {
+		$should_switch = is_multisite() && $blog_id && get_current_blog_id() !== $blog_id;
+
+		if ( $should_switch ) {
+			switch_to_blog( $blog_id );
+		}
+
+		$term = amnesty_get_a_post_term( $post_id, $taxonomy );
+
+		if ( $should_switch ) {
+			restore_current_blog();
+		}
+
+		return $term;
+	}
+}
+
 if ( ! function_exists( 'amnesty_post_type_is_enabled' ) ) {
 	/**
 	 * Check whether a post type is enabled via network admin

--- a/wp-content/themes/humanity-theme/patterns/search.php
+++ b/wp-content/themes/humanity-theme/patterns/search.php
@@ -10,30 +10,35 @@
 $search_object = amnesty_get_searchpage_query_object();
 $location_slug = get_option( 'amnesty_location_slug' ) ?: 'location';
 
-$has_term = function ( string $taxonomy = 'category' ): bool {
-	switch_to_blog( get_post()->blog_id );
-	$term = amnesty_get_a_post_term( get_the_ID(), $taxonomy );
-	restore_current_blog();
+// results may come from another site on the network; switching is only possible (and needed) when they do
+$result_blog_id = function (): int {
+	$blog_id = absint( get_post()->blog_id ?? 0 );
 
-	return (bool) $term;
+	return ( is_multisite() && $blog_id && get_current_blog_id() !== $blog_id ) ? $blog_id : 0;
 };
 
-$term_link = function ( string $taxonomy = 'category' ): string {
-	switch_to_blog( get_post()->blog_id );
-	$term = amnesty_get_a_post_term( get_the_ID(), $taxonomy );
-	restore_current_blog();
-
-	$switch = isset( get_post()->blog_id ) && absint( get_post()->blog_id ) !== get_current_blog_id();
-
-	return $term ? amnesty_cross_blog_term_link( $term, $switch ) : '';
+$get_term = function ( string $taxonomy = 'category' ) use ( $result_blog_id ): ?WP_Term {
+	return get_blog_post_term( $result_blog_id(), get_the_ID(), $taxonomy );
 };
 
-$term_name = function ( string $taxonomy = 'category' ): ?string {
-	switch_to_blog( get_post()->blog_id );
-	$term = amnesty_get_a_post_term( get_the_ID(), $taxonomy );
-	restore_current_blog();
+$has_term = function ( string $taxonomy = 'category' ) use ( $get_term ): bool {
+	return (bool) $get_term( $taxonomy );
+};
 
-	return $term->name;
+$term_link = function ( string $taxonomy = 'category' ) use ( $get_term, $result_blog_id ): string {
+	$term = $get_term( $taxonomy );
+
+	return $term ? amnesty_cross_blog_term_link( $term, (bool) $result_blog_id() ) : '';
+};
+
+$term_name = function ( string $taxonomy = 'category' ) use ( $get_term ): ?string {
+	return $get_term( $taxonomy )?->name;
+};
+
+$post_permalink = function () use ( $result_blog_id ): string {
+	$blog_id = $result_blog_id();
+
+	return (string) ( $blog_id ? get_blog_permalink( $blog_id, get_the_ID() ) : get_permalink( get_the_ID() ) );
 };
 
 ?>
@@ -104,7 +109,7 @@ $term_name = function ( string $taxonomy = 'category' ): ?string {
 
 					<!-- wp:heading {"level":2,"className":"post-title wp-block-post-title"} -->
 					<h2 class="wp-block-heading post-title wp-block-post-title">
-						<a href="<?php echo esc_url( get_blog_permalink( get_post()->blog_id, get_the_ID() ) ); ?>" target="_self"><?php the_title(); ?></a>
+						<a href="<?php echo esc_url( $post_permalink() ); ?>" target="_self"><?php the_title(); ?></a>
 					</h2>
 					<!-- /wp:heading -->
 					<!-- wp:group {"tagName":"div","className":"post-excerpt wp-block-post-excerpt"} -->


### PR DESCRIPTION
Ref: #785

Hi! first time contributor here 😄 

Fixes the endless redirect loop when searching on a non-multisite install, plus two more single-site search bugs that were hiding behind it.

## What's going on
`amnesty_maybe_override_search_uri()` is hooked into `home_url` and rewrites any `/search/<term>/` path to the bare search page URL. On single-site, `current_url()` goes through `home_url()`, so on `/search/foo/` it reported `/search/` which never matches the target URL `prettify_search()` wants you on, so it 302s you to the page you're already on, forever. Multisite doesn't loop because `current_url()` builds from the network siteurl option and never touches `home_url()` on that path.

I looked at dropping the non-multisite branch in `current_url()` as suggested in the issue, but building from the `siteurl` option would break single-site installs where WordPress lives in its own directory (like a Bedrock setup) they would loop again. Suspending the override while `current_url()` builds its result feels like the safest fix: the current URL should always be the literal request URL. I left the `home_url` filter itself alone, since form actions and `get_pagenum_link()` and derived URLs depend on its rewriting.

With the loop fixed, two more single-site problems surfaced:

1. The search results pattern fatals — it calls `switch_to_blog()` / `get_blog_permalink()` unconditionally, and those don't exist outside multisite. Added a `get_blog_post_term()` helper (modelled on the existing `get_blog_post_meta()`) that only switches when a result actually comes from another site.
2. The title filters (`title_tag()` / `results_title()`) never applied on plain-http sites: `current_url()` forces https while `amnesty_search_url()` follows the site scheme, so their `strpos()` guards couldn't match. Normalised both sides with `set_url_scheme()`, as `prettify_search()` already does.

## Steps to test:
1. Fresh single-site install, pretty permalinks enabled, no search page configured
2. Run a search via `/?s=foo` or `/search/foo/`   ( before this PR the browser dies in a redirect loop and after, there's a single 302 to `/search/foo/` and results render)
3. Check result title links, term links, and the "N results for …" heading
4. On multisite, verify search works like usual

## Considerations:
- Multisite: `current_url()`'s multisite branch is untouched. The results pattern still switches sites when a result comes from another site on the network, it now just skips the switch when the result is already from the current site, which previously did nothing anyway.
- The `home_url` override is intentionally kept
- No user-facing strings or markup changed, so no localisation/a11y impact
- I branched from `develop` instead of `main` because `main` has some commits that were not merged back into `develop`.  

Video 
[humanity-theme-785-search-fix-before-after.webm](https://github.com/user-attachments/assets/72554516-98e5-4ea2-8c48-f6d421340c43)

