### PR TITLE
Support for WP 6.9

### DIFF
--- a/private/src/scripts/editor/blocks-deprecated/background-media/components/ColumnDisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/background-media/components/ColumnDisplayComponent.jsx
@@ -97,6 +97,8 @@ const DisplayComponent = (props) => {
               onChange={setFocalPoint}
             />
             <RangeControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Opacity', 'amnesty')}
               min={0}

--- a/private/src/scripts/editor/blocks-deprecated/background-media/components/ColumnDisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/background-media/components/ColumnDisplayComponent.jsx
@@ -113,6 +113,8 @@ const DisplayComponent = (props) => {
           // translators: [admin]
           <PanelBody title={__('Background Colour', 'amnesty')}>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Colour', 'amnesty')}
               value={background}

--- a/private/src/scripts/editor/blocks-deprecated/banner/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/banner/DisplayComponent.jsx
@@ -195,6 +195,8 @@ export default class DisplayComponent extends Component {
               setAttributes={setAttributes}
             />
             <TextControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Embed URL', 'amnesty')}
               // translators: [admin]

--- a/private/src/scripts/editor/blocks-deprecated/banner/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/banner/DisplayComponent.jsx
@@ -4,7 +4,7 @@ import MediaMetadataVisibilityControls from '../../components/MediaMetadataVisib
 import PostFeaturedVideo from '../../components/PostFeaturedVideo.jsx';
 
 const { InspectorControls, MediaUpload, RichText, URLInputButton } = wp.blockEditor;
-const { IconButton, PanelBody, SelectControl, TextControl } = wp.components;
+const { Button, PanelBody, SelectControl, TextControl } = wp.components;
 const { Component, Fragment } = wp.element;
 const { __ } = wp.i18n;
 const { addQueryArgs } = wp.url;
@@ -211,7 +211,7 @@ export default class DisplayComponent extends Component {
           {type !== 'video' && (
             <div className="linkList-options">
               {imageID ? (
-                <IconButton
+                <Button
                   icon="no-alt"
                   // translators: [admin]
                   label={__('Remove Image', 'amnesty')}
@@ -222,7 +222,7 @@ export default class DisplayComponent extends Component {
                   allowedTypes={['image']}
                   value={imageID}
                   onSelect={(media) => setAttributes({ imageID: media.id })}
-                  render={({ open }) => <IconButton icon="format-image" onClick={open} />}
+                  render={({ open }) => <Button icon="format-image" onClick={open} />}
                 />
               )}
             </div>

--- a/private/src/scripts/editor/blocks-deprecated/banner/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/banner/DisplayComponent.jsx
@@ -118,6 +118,8 @@ export default class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Alignment', 'amnesty')}
               options={[
@@ -141,6 +143,8 @@ export default class DisplayComponent extends Component {
               onChange={(newAlignment) => setAttributes({ alignment: newAlignment })}
             />
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Colour', 'amnesty')}
               options={[
@@ -157,6 +161,8 @@ export default class DisplayComponent extends Component {
               onChange={(newBackground) => setAttributes({ background: newBackground })}
             />
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Size', 'amnesty')}
               options={[
@@ -169,6 +175,8 @@ export default class DisplayComponent extends Component {
               onChange={(newSize) => setAttributes({ size: newSize })}
             />
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Type', 'amnesty')}
               options={[

--- a/private/src/scripts/editor/blocks-deprecated/button/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/button/DisplayComponent.jsx
@@ -27,6 +27,8 @@ class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Button Style', 'amnesty')}
               options={[

--- a/private/src/scripts/editor/blocks-deprecated/call-to-action/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/call-to-action/DisplayComponent.jsx
@@ -62,6 +62,8 @@ class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Style', 'amnesty')}
               options={[

--- a/private/src/scripts/editor/blocks-deprecated/collapsable/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/collapsable/DisplayComponent.jsx
@@ -44,6 +44,8 @@ const DisplayComponent = ({ attributes, className, setAttributes }) => {
         <PanelBody title={__('Settings', 'amnesty')}>
           <PanelRow>
             <ToggleControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Collapsed by default', 'amnesty')}
               // translators: [admin]

--- a/private/src/scripts/editor/blocks-deprecated/collapsable/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/collapsable/DisplayComponent.jsx
@@ -54,6 +54,8 @@ const DisplayComponent = ({ attributes, className, setAttributes }) => {
           </PanelRow>
           <PanelRow>
             <TextControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               label={__('HTML anchor')}
               // translators: [admin]
               help={__('Label this block with an HTML anchor (#example).', 'amnesty')}

--- a/private/src/scripts/editor/blocks-deprecated/columns/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/columns/DisplayComponent.jsx
@@ -28,6 +28,8 @@ class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Layout Style', 'amnesty')}
               options={options}

--- a/private/src/scripts/editor/blocks-deprecated/custom-card/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/custom-card/DisplayComponent.jsx
@@ -56,6 +56,8 @@ export default class BlockEdit extends Component {
         <InspectorControls>
           <PanelBody>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Size', 'amnesty')}
               value={style}

--- a/private/src/scripts/editor/blocks-deprecated/custom-card/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/custom-card/DisplayComponent.jsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 
 const { InspectorControls, MediaUpload, RichText, URLInputButton } = wp.blockEditor;
-const { IconButton, PanelBody, SelectControl, TextControl } = wp.components;
+const { Button, PanelBody, SelectControl, TextControl } = wp.components;
 const { Component, Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -88,7 +88,7 @@ export default class BlockEdit extends Component {
           <div className="customCard-figure">
             <div className="linkList-options">
               {imageID ? (
-                <IconButton
+                <Button
                   icon="no-alt"
                   // translators: [admin]
                   label={__('Remove Image', 'amnesty')}
@@ -106,7 +106,7 @@ export default class BlockEdit extends Component {
                       imageAlt: media.alt,
                     })
                   }
-                  render={({ open }) => <IconButton icon="format-image" onClick={open} />}
+                  render={({ open }) => <Button icon="format-image" onClick={open} />}
                 />
               )}
             </div>

--- a/private/src/scripts/editor/blocks-deprecated/custom-card/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/custom-card/DisplayComponent.jsx
@@ -70,6 +70,8 @@ export default class BlockEdit extends Component {
               ]}
             />
             <TextControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Scroll To Link', 'amnesty')}
               value={attributes.scrollLink}

--- a/private/src/scripts/editor/blocks-deprecated/custom-card/index.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/custom-card/index.jsx
@@ -31,6 +31,7 @@ const blockAttributes = {
   },
   scrollLink: {
     type: 'string',
+    default: '',
   },
   linkText: {
     type: 'string',

--- a/private/src/scripts/editor/blocks-deprecated/header/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/header/DisplayComponent.jsx
@@ -146,6 +146,8 @@ class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Alignment', 'amnesty')}
               options={[
@@ -169,6 +171,8 @@ class DisplayComponent extends Component {
               onChange={this.createUpdateAttribute('alignment')}
             />
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Colour', 'amnesty')}
               options={[
@@ -187,6 +191,8 @@ class DisplayComponent extends Component {
               onChange={this.createUpdateAttribute('background')}
             />
             <SelectControl
+              __nextHasNo__next40pxDefaultSize
+              __nextHasNoMarginBottomMarginBottom
               // translators: [admin]
               label={__('Size', 'amnesty')}
               options={[
@@ -206,6 +212,8 @@ class DisplayComponent extends Component {
             />
 
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Type', 'amnesty')}
               options={[

--- a/private/src/scripts/editor/blocks-deprecated/header/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/header/DisplayComponent.jsx
@@ -192,7 +192,7 @@ class DisplayComponent extends Component {
             />
             <SelectControl
               __nextHasNo__next40pxDefaultSize
-              __nextHasNoMarginBottomMarginBottom
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Size', 'amnesty')}
               options={[

--- a/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
@@ -7,7 +7,7 @@ const { Component, Fragment } = wp.element;
 const { __ } = wp.i18n;
 
 const getClosestSize = (media) => {
-  const sizeList = media.sizes || media.media_details.sizes;
+  const sizeList = media?.sizes || media?.media_details?.sizes || {};
   const sizes = {};
 
   Object.keys(sizeList).forEach((size) => {
@@ -58,8 +58,8 @@ export default class DisplayComponent extends Component {
       size = getClosestSize(media);
     }
 
-    const sizeList = media.sizes || media.media_details.sizes;
-    const url = sizeList[size].url || sizeList[size].source_url;
+    const sizeList = media?.sizes || media?.media_details?.sizes || {};
+    const url = sizeList[size]?.url || sizeList[size]?.source_url;
 
     this.setState({ image: media });
     this.props.setAttributes({ imageID: media.id, imageURL: url });

--- a/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
@@ -43,6 +43,10 @@ export default class DisplayComponent extends Component {
       key = 'video';
     }
 
+    if (!mediaID) {
+      return;
+    }
+
     wp.apiRequest({ path: `/wp/v2/media/${mediaID}` }).then((response) =>
       this.setState({ [key]: response }),
     );

--- a/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 
 const { React } = window;
 const { InspectorControls, MediaUpload, PlainText, RichText, URLInputButton } = wp.blockEditor;
-const { Button, IconButton, PanelBody, SelectControl, ToggleControl } = wp.components;
+const { Button, PanelBody, SelectControl, ToggleControl } = wp.components;
 const { Component, Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -130,7 +130,7 @@ export default class DisplayComponent extends Component {
         </div>
         <div className="linkList-options">
           {buttons.length > 1 && (
-            <IconButton
+            <Button
               icon="no-alt"
               // translators: [admin]
               label={__('Remove Button', 'amnesty')}
@@ -212,7 +212,7 @@ export default class DisplayComponent extends Component {
     return (
       <div className="linkList-options imageBlock-action">
         {imageID ? (
-          <IconButton
+          <Button
             icon="no-alt"
             // translators: [admin]
             label={__('Remove Image', 'amnesty')}
@@ -236,7 +236,7 @@ export default class DisplayComponent extends Component {
                 });
               });
             }}
-            render={({ open }) => <IconButton icon="format-image" onClick={open} />}
+            render={({ open }) => <Button icon="format-image" onClick={open} />}
           />
         )}
       </div>
@@ -272,7 +272,7 @@ export default class DisplayComponent extends Component {
         <div className="imageBlock-buttonsContainer">
           {buttons.map((button, index) => this.createButton(index, button))}
           {buttons.length < 1 && this.createButton(0)}
-          <IconButton
+          <Button
             icon="plus"
             // translators: [admin]
             label={__('Add Button', 'amnesty')}

--- a/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
@@ -409,12 +409,16 @@ export default class DisplayComponent extends Component {
 
           <PanelBody>
             <ToggleControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Display Overlay', 'amnesty')}
               checked={hasOverlay}
               onChange={(newHasOverlay) => setAttributes({ hasOverlay: newHasOverlay })}
             />
             <ToggleControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Enable Parallax', 'amnesty')}
               checked={parallax}

--- a/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
@@ -169,6 +169,8 @@ export default class DisplayComponent extends Component {
     return (
       <PanelBody>
         <SelectControl
+          __next40pxDefaultSize
+          __nextHasNoMarginBottom
           // translators: [admin]
           label={__('Image Style', 'amnesty')}
           value={style}
@@ -181,6 +183,8 @@ export default class DisplayComponent extends Component {
           ]}
         />
         <SelectControl
+          __next40pxDefaultSize
+          __nextHasNoMarginBottom
           // translators: [admin]
           label={__('Alignment', 'amnesty')}
           // translators: [admin]
@@ -380,6 +384,8 @@ export default class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Type', 'amnesty')}
               options={[

--- a/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/image/DisplayComponent.jsx
@@ -326,7 +326,7 @@ export default class DisplayComponent extends Component {
               <video>
                 <source src={videoURL} />
               </video>
-              <Button onClick={open} isSecondary isLarge>
+              <Button onClick={open} isSecondary>
                 {/* translators: [admin] */ __('Replace Video', 'amnesty')}
               </Button>
             </div>

--- a/private/src/scripts/editor/blocks-deprecated/links-with-icons/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/links-with-icons/DisplayComponent.jsx
@@ -85,6 +85,8 @@ export default class DisplayComponent extends Component {
             />
             {style !== 'square' && (
               <SelectControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
                 // translators: [admin]
                 label={__('Orientation', 'amnesty')}
                 value={orientation}
@@ -98,6 +100,8 @@ export default class DisplayComponent extends Component {
               />
             )}
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Colour', 'amnesty')}
               value={backgroundColor}
@@ -118,6 +122,8 @@ export default class DisplayComponent extends Component {
               />
             )}
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               className="radio-control-icons"
               // translators: [admin]
               label={__('Divider Style', 'amnesty')}

--- a/private/src/scripts/editor/blocks-deprecated/links-with-icons/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/links-with-icons/DisplayComponent.jsx
@@ -115,6 +115,8 @@ export default class DisplayComponent extends Component {
             />
             {style !== 'square' && (
               <ToggleControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
                 // translators: [admin]
                 label={__('Hide Lines', 'amnesty')}
                 checked={hideLines}

--- a/private/src/scripts/editor/blocks-deprecated/links-with-icons/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/links-with-icons/DisplayComponent.jsx
@@ -74,6 +74,8 @@ export default class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody>
             <RangeControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Quantity', 'amnesty')}
               value={quantity}

--- a/private/src/scripts/editor/blocks-deprecated/links-with-icons/InnerDisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/links-with-icons/InnerDisplayComponent.jsx
@@ -149,6 +149,8 @@ export default class BlockEdit extends Component {
       <InspectorControls>
         <PanelBody>
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Style', 'amnesty')}
             value={style}
@@ -164,6 +166,8 @@ export default class BlockEdit extends Component {
           />
           {['icon', 'square'].includes(style) && (
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Icon Size', 'amnesty')}
               value={iconSize}
@@ -182,6 +186,8 @@ export default class BlockEdit extends Component {
           )}
           {['icon', 'square'].includes(style) && (
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Icon Position', 'amnesty')}
               value={imageLocation}
@@ -235,6 +241,8 @@ export default class BlockEdit extends Component {
           />
           {hasButton && style !== 'square' && (
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Button Style', 'amnesty')}
               options={[

--- a/private/src/scripts/editor/blocks-deprecated/links-with-icons/InnerDisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/links-with-icons/InnerDisplayComponent.jsx
@@ -196,6 +196,7 @@ export default class BlockEdit extends Component {
           )}
           {style === 'icon' && (
             <CheckboxControl
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Hide Image Credit Display', 'amnesty')}
               checked={uncredited}
@@ -205,6 +206,7 @@ export default class BlockEdit extends Component {
           {style === 'text' && (
             <Fragment>
               <CheckboxControl
+                __nextHasNoMarginBottom
                 // translators: [admin]
                 label={__('Has Underline', 'amnesty')}
                 checked={underlined}
@@ -223,6 +225,7 @@ export default class BlockEdit extends Component {
             </Fragment>
           )}
           <CheckboxControl
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Display Action', 'amnesty')}
             checked={hasButton}

--- a/private/src/scripts/editor/blocks-deprecated/links-with-icons/InnerDisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks-deprecated/links-with-icons/InnerDisplayComponent.jsx
@@ -213,6 +213,8 @@ export default class BlockEdit extends Component {
                 onChange={(newUnderline) => setAttributes({ underlined: newUnderline })}
               />
               <RangeControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
                 // translators: [admin]
                 label={__('Font Size', 'amnesty')}
                 value={factFontSize}

--- a/private/src/scripts/editor/blocks/action/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/action/DisplayComponent.jsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 
 const { InspectorControls, MediaUpload, PlainText, URLInputButton } = wp.blockEditor;
-const { IconButton, PanelBody, SelectControl } = wp.components;
+const { Button, PanelBody, SelectControl } = wp.components;
 const { Component, Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -100,7 +100,7 @@ export default class BlockEdit extends Component {
           <div className="actionBlock-figure">
             <div className="linkList-options">
               {imageID ? (
-                <IconButton
+                <Button
                   icon="no-alt"
                   // translators: [admin]
                   label={__('Remove Image', 'amnesty')}
@@ -118,7 +118,7 @@ export default class BlockEdit extends Component {
                       imageAlt: media.alt,
                     })
                   }
-                  render={({ open }) => <IconButton icon="format-image" onClick={open} />}
+                  render={({ open }) => <Button icon="format-image" onClick={open} />}
                 />
               )}
             </div>

--- a/private/src/scripts/editor/blocks/action/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/action/DisplayComponent.jsx
@@ -83,6 +83,8 @@ export default class BlockEdit extends Component {
         <InspectorControls>
           <PanelBody>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Size', 'amnesty')}
               value={style}

--- a/private/src/scripts/editor/blocks/blockquote/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/blockquote/DisplayComponent.jsx
@@ -109,6 +109,8 @@ class DisplayComponent extends Component {
             />
             {!this.isRightToLeft && (
               <ToggleControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
                 // translators: [admin]
                 label={__('Capitalise', 'amnesty')}
                 // translators: [admin]
@@ -118,6 +120,8 @@ class DisplayComponent extends Component {
               />
             )}
             <ToggleControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Line', 'amnesty')}
               // translators: [admin]

--- a/private/src/scripts/editor/blocks/blockquote/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/blockquote/DisplayComponent.jsx
@@ -67,6 +67,8 @@ class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Alignment', 'amnesty')}
               value={align}
@@ -74,6 +76,8 @@ class DisplayComponent extends Component {
               options={this.getDirections()}
             />
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Size', 'amnesty')}
               value={size}
@@ -88,6 +92,8 @@ class DisplayComponent extends Component {
               ]}
             />
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Text Colour', 'amnesty')}
               value={colour}

--- a/private/src/scripts/editor/blocks/countdown-timer/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/countdown-timer/DisplayComponent.jsx
@@ -111,6 +111,8 @@ const DisplayComponent = ({ attributes, setAttributes }) => {
             is12Hour={true}
           />
           <TextControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Time Expired Text', 'amnesty')}
             className="expiredTextBox"

--- a/private/src/scripts/editor/blocks/download/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/download/DisplayComponent.jsx
@@ -137,6 +137,8 @@ class DisplayComponent extends Component {
       <InspectorControls>
         <PanelBody>
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Button Style', 'amnesty')}
             options={buttonStyles}

--- a/private/src/scripts/editor/blocks/embed-flourish/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/embed-flourish/DisplayComponent.jsx
@@ -35,6 +35,8 @@ const DisplayComponent = (props) => {
   return (
     <Fragment>
       <TextControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         value={httpsOnly(attributes.source)}
         onChange={(source) => setAttributes({ source })}
         // translators: [admin]

--- a/private/src/scripts/editor/blocks/embed-infogram/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/embed-infogram/DisplayComponent.jsx
@@ -8,6 +8,8 @@ const DisplayComponent = (props) => {
   return (
     <Fragment>
       <TextControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         // translators: [admin]
         label={__('The embed code', 'amnesty')}
         value={attributes.identifier}
@@ -15,6 +17,8 @@ const DisplayComponent = (props) => {
         placeholder="e.g. 75e11a7d-a5bb-45b2-9764-b5fdbdfdf489"
       />
       <TextControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         // translators: [admin]
         label={__('The embed type', 'amnesty')}
         value={attributes.type}
@@ -22,6 +26,8 @@ const DisplayComponent = (props) => {
         placeholder="e.g. 'interactive'"
       />
       <TextControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         // translators: [admin]
         label={__('The embed title', 'amnesty')}
         value={attributes.title}

--- a/private/src/scripts/editor/blocks/embed-sutori/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/embed-sutori/DisplayComponent.jsx
@@ -32,6 +32,8 @@ const DisplayComponent = (props) => {
   return (
     <Fragment>
       <TextControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         value={httpsOnly(attributes.source)}
         onChange={(source) => getIframeSrc(source, props)}
         // translators: [admin]

--- a/private/src/scripts/editor/blocks/embed-tickcounter/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/embed-tickcounter/DisplayComponent.jsx
@@ -32,6 +32,8 @@ const DisplayComponent = (props) => {
         )}
       >
         <TextControl
+          __next40pxDefaultSize
+          __nextHasNoMarginBottom
           value={httpsOnly(attributes.source)}
           onChange={(source) => setAttributes({ source: httpsOnly(stripScript(source)) })}
           // translators: [admin]

--- a/private/src/scripts/editor/blocks/hero/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/hero/DisplayComponent.jsx
@@ -86,6 +86,8 @@ const DisplayComponent = (props) => {
     <InspectorControls>
       <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')} initialOpen={true}>
         <SelectControl
+          __next40pxDefaultSize
+          __nextHasNoMarginBottom
           label={/* translators: [admin] */ __('Background Colour', 'amnesty')}
           options={[
             { label: /* translators: [admin] */ __('Black', 'amnesty'), value: 'dark' },
@@ -95,6 +97,8 @@ const DisplayComponent = (props) => {
           onChange={(background) => setAttributes({ background })}
         />
         <SelectControl
+          __next40pxDefaultSize
+          __nextHasNoMarginBottom
           label={/* translators: [admin] */ __('Background Type', 'amnesty')}
           options={[
             { label: /* translators: [admin] */ __('Image', 'amnesty'), value: 'image' },

--- a/private/src/scripts/editor/blocks/hero/components/BlockImageSelector.jsx
+++ b/private/src/scripts/editor/blocks/hero/components/BlockImageSelector.jsx
@@ -1,5 +1,5 @@
 const { MediaUpload } = wp.blockEditor;
-const { IconButton } = wp.components;
+const { Button } = wp.components;
 const { __ } = wp.i18n;
 
 /**
@@ -12,7 +12,7 @@ const { __ } = wp.i18n;
 const BlockImageSelector = ({ imageId, setAttributes }) => {
   if (imageId) {
     return (
-      <IconButton
+      <Button
         icon="no-alt"
         // translators: [admin]
         label={__('Remove Image', 'amnesty')}
@@ -26,7 +26,7 @@ const BlockImageSelector = ({ imageId, setAttributes }) => {
       allowedTypes={['image']}
       value={imageId}
       onSelect={({ id }) => setAttributes({ imageID: id })}
-      render={({ open }) => <IconButton icon="format-image" onClick={open} />}
+      render={({ open }) => <Button icon="format-image" onClick={open} />}
     />
   );
 };

--- a/private/src/scripts/editor/blocks/iframe-button/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/iframe-button/DisplayComponent.jsx
@@ -85,10 +85,10 @@ const DisplayComponent = (props) => {
           value={embedUrl}
           onChange={() => setEmbedUrl(inputRef.current.value)}
         />
-        <Button isLarge isPrimary onClick={embed}>
+        <Button isPrimary onClick={embed}>
           {/* translators: [admin] */ __('Embed', 'amnesty')}
         </Button>
-        <Button isLarge onClick={() => setIsPreviewing(!previewing)}>
+        <Button onClick={() => setIsPreviewing(!previewing)}>
           {previewing
             ? /* translators: [admin] */ __('Hide Preview', 'amnesty')
             : /* translators: [admin] */ __('Preview', 'amnesty')}

--- a/private/src/scripts/editor/blocks/iframe-button/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/iframe-button/DisplayComponent.jsx
@@ -34,6 +34,8 @@ const DisplayComponent = (props) => {
       <InspectorControls>
         <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
           <TextControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Iframe Height', 'amnesty')}
             value={attributes.iframeHeight}
@@ -42,6 +44,8 @@ const DisplayComponent = (props) => {
             onChange={(iframeHeight) => setAttributes({ iframeHeight })}
           />
           <TextControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Iframe Title', 'amnesty')}
             // translators: [admin]

--- a/private/src/scripts/editor/blocks/iframe-button/index.jsx
+++ b/private/src/scripts/editor/blocks/iframe-button/index.jsx
@@ -23,6 +23,7 @@ registerBlockType('amnesty-core/iframe-button', {
     },
     iframeUrl: {
       type: 'string',
+      default: '',
     },
     iframeHeight: {
       type: 'number',
@@ -30,9 +31,11 @@ registerBlockType('amnesty-core/iframe-button', {
     },
     buttonText: {
       type: 'string',
+      default: '',
     },
     title: {
       type: 'string',
+      default: '',
     },
   },
   supports: {

--- a/private/src/scripts/editor/blocks/iframe/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/iframe/DisplayComponent.jsx
@@ -113,6 +113,8 @@ class DisplayComponent extends Component {
       <InspectorControls>
         <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
           <TextControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Width', 'amnesty')}
             value={attributes.width}
@@ -127,6 +129,8 @@ class DisplayComponent extends Component {
             onChange={this.createUpdateAttribute('width')}
           />
           <TextControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Height', 'amnesty')}
             value={attributes.height}
@@ -141,6 +145,8 @@ class DisplayComponent extends Component {
             onChange={this.createUpdateAttribute('height')}
           />
           <TextControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Minimum Height', 'amnesty')}
             value={attributes.minHeight}
@@ -158,6 +164,8 @@ class DisplayComponent extends Component {
           />
           <hr />
           <TextControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Iframe Title', 'amnesty')}
             // translators: [admin]

--- a/private/src/scripts/editor/blocks/iframe/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/iframe/DisplayComponent.jsx
@@ -46,8 +46,11 @@ class DisplayComponent extends Component {
             // translators: [admin]
             placeholder={__('Enter URL to embed here…', 'amnesty')}
           />
-          <Button isLarge type="submit">
-            {/* translators: [admin] */ __('Embed', 'amnesty')}
+          <Button type="submit">
+            {
+              /* translators: [admin] */
+              __('Embed', 'amnesty')
+            }
           </Button>
         </form>
       </Placeholder>

--- a/private/src/scripts/editor/blocks/key-facts/index.jsx
+++ b/private/src/scripts/editor/blocks/key-facts/index.jsx
@@ -47,6 +47,8 @@ registerBlockType('amnesty-core/key-facts', {
         <InspectorControls>
           <PanelBody>
             <RangeControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Quantity', 'amnesty')}
               value={quantity}

--- a/private/src/scripts/editor/blocks/key-facts/index.jsx
+++ b/private/src/scripts/editor/blocks/key-facts/index.jsx
@@ -57,6 +57,8 @@ registerBlockType('amnesty-core/key-facts', {
               max={4}
             />
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Colour', 'amnesty')}
               value={background}

--- a/private/src/scripts/editor/blocks/link-group/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/link-group/DisplayComponent.jsx
@@ -165,6 +165,7 @@ class DisplayComponent extends Component {
                   onChange={(link) => this.updateItemLink(index, link)}
                 />
                 <CheckboxControl
+                  __nextHasNoMarginBottom
                   className="newtab"
                   // translators: [admin]
                   label={__('Open in new tab', 'amnesty')}

--- a/private/src/scripts/editor/blocks/menu/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/menu/DisplayComponent.jsx
@@ -152,6 +152,8 @@ class DisplayComponent extends Component {
               <p>{/* translators: [admin] */ __('Loading Menus…', 'amnesty')}</p>
             )}
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Menu', 'amnesty')}
               // translators: [admin]
@@ -167,6 +169,8 @@ class DisplayComponent extends Component {
             />
             {attributes.type === 'standard-menu' && (
               <SelectControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
                 // translators: [admin]
                 label={__('Menu', 'amnesty')}
                 options={this.state.list}
@@ -176,6 +180,8 @@ class DisplayComponent extends Component {
               />
             )}
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Colour', 'amnesty')}
               options={DisplayComponent.colours}

--- a/private/src/scripts/editor/blocks/post-list/PostsWrapper.jsx
+++ b/private/src/scripts/editor/blocks/post-list/PostsWrapper.jsx
@@ -168,6 +168,8 @@ const PostsWrapper = createHigherOrderComponent((BlockEdit) => {
             <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
               {defaultStyleOptions.length > 0 && (
                 <SelectControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom
                   // translators: [admin]
                   label={__('Style', 'amnesty')}
                   options={defaultStyleOptions}
@@ -176,6 +178,8 @@ const PostsWrapper = createHigherOrderComponent((BlockEdit) => {
                 />
               )}
               <SelectControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
                 // translators: [admin]
                 label={__('Type', 'amnesty')}
                 options={defaultDisplayTypes}

--- a/private/src/scripts/editor/blocks/post-list/PostsWrapper.jsx
+++ b/private/src/scripts/editor/blocks/post-list/PostsWrapper.jsx
@@ -235,6 +235,8 @@ const PostsWrapper = createHigherOrderComponent((BlockEdit) => {
               )}
               {attributes.type === 'category' && (
                 <ToggleControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom
                   // translators: [admin]
                   label={__('Use related categories where supported', 'amnesty')}
                   checked={attributes.categoryRelated}
@@ -283,12 +285,16 @@ const PostsWrapper = createHigherOrderComponent((BlockEdit) => {
                 </label>
               )}
               <ToggleControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
                 // translators: [admin]
                 label={__('Display Post Author', 'amnesty')}
                 checked={attributes.displayAuthor}
                 onChange={this.createUpdateAttribute('displayAuthor')}
               />
               <ToggleControl
+                __next40pxDefaultSize
+                __nextHasNoMarginBottom
                 // translators: [admin]
                 label={__('Display Post Date', 'amnesty')}
                 checked={attributes.displayPostDate}

--- a/private/src/scripts/editor/blocks/post-list/PostsWrapper.jsx
+++ b/private/src/scripts/editor/blocks/post-list/PostsWrapper.jsx
@@ -195,6 +195,8 @@ const PostsWrapper = createHigherOrderComponent((BlockEdit) => {
               )}
               {attributes.type === 'category' && (
                 <RangeControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom
                   // translators: [admin]
                   label={__('Number of posts to show:', 'amnesty')}
                   min={1}
@@ -205,6 +207,8 @@ const PostsWrapper = createHigherOrderComponent((BlockEdit) => {
               )}
               {attributes.type === 'feed' && (
                 <RangeControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom
                   // translators: [admin]
                   label={__('Number of posts to show:', 'amnesty')}
                   min={1}
@@ -215,6 +219,8 @@ const PostsWrapper = createHigherOrderComponent((BlockEdit) => {
               )}
               {attributes.type === 'taxonomy' && (
                 <RangeControl
+                  __next40pxDefaultSize
+                  __nextHasNoMarginBottom
                   // translators: [admin]
                   label={__('Number of posts to show:', 'amnesty')}
                   min={1}

--- a/private/src/scripts/editor/blocks/post-list/components/category-select.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/category-select.jsx
@@ -12,7 +12,9 @@ class CategorySelect extends Component {
       options: [],
       route: '/amnesty/v1/categories',
     };
+  }
 
+  componentDidMount() {
     this.fetch();
   }
 

--- a/private/src/scripts/editor/blocks/post-list/components/editable/GridItem.jsx
+++ b/private/src/scripts/editor/blocks/post-list/components/editable/GridItem.jsx
@@ -1,5 +1,5 @@
 const { RichText, URLInputButton, MediaUpload } = wp.blockEditor;
-const { IconButton } = wp.components;
+const { Button } = wp.components;
 const { __ } = wp.i18n;
 const { get } = lodash;
 
@@ -33,7 +33,7 @@ const GridItem = (props) => (
     </div>
     <div className="linkList-options">
       {props.featured_image_id && props.featured_image_id !== -1 && (
-        <IconButton
+        <Button
           icon="no-alt"
           onClick={() =>
             props.updateMedia({
@@ -43,7 +43,7 @@ const GridItem = (props) => (
           }
         >
           {/* translators: [admin] */ __('Remove Image', 'amnesty')}
-        </IconButton>
+        </Button>
       )}
       <MediaUpload
         onSelect={({ id, sizes, url }) =>
@@ -54,9 +54,9 @@ const GridItem = (props) => (
         }
         value={props.featured_image_id}
         allowedTypes={['image']}
-        render={({ open }) => <IconButton icon="format-image" onClick={open} />}
+        render={({ open }) => <Button icon="format-image" onClick={open} />}
       />
-      <IconButton onClick={props.createRemove} icon="trash" />
+      <Button onClick={props.createRemove} icon="trash" />
     </div>
   </article>
 );

--- a/private/src/scripts/editor/blocks/post-meta/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/post-meta/DisplayComponent.jsx
@@ -81,6 +81,8 @@ export default function DisplayComponent({ attributes, context, setAttributes })
       <InspectorControls>
         <PanelBody title={__('Settings', 'default')}>
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             label={__('Choose a meta key', 'amnesty')}
             value={attributes.metaKey}
             options={[{ label: __('None', 'default'), value: '' }, ...metaKeys]}

--- a/private/src/scripts/editor/blocks/post-meta/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/post-meta/DisplayComponent.jsx
@@ -89,11 +89,14 @@ export default function DisplayComponent({ attributes, context, setAttributes })
             onChange={(metaKey) => setAttributes({ metaKey })}
           />
           <ToggleControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             label={__('Does this meta key have a single value?', 'amnesty')}
             checked={isSingle}
             onChange={() => setAttributes({ isSingle: !isSingle })}
           />
           <ToggleControl
+            __next40pxDefaultSize
             __nextHasNoMarginBottom
             label={
               postType?.labels.singular_name

--- a/private/src/scripts/editor/blocks/regions/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/regions/DisplayComponent.jsx
@@ -197,6 +197,8 @@ export default class DisplayComponent extends Component {
             />
           )}
           <ToggleControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Show only Regions/Subregions', 'amnesty')}
             checked={attributes.regionsOnly}

--- a/private/src/scripts/editor/blocks/regions/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/regions/DisplayComponent.jsx
@@ -182,6 +182,8 @@ export default class DisplayComponent extends Component {
           />
           {hierarchical && (
             <RangeControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Max depth', 'amnesty')}
               min={0}

--- a/private/src/scripts/editor/blocks/regions/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/regions/DisplayComponent.jsx
@@ -162,6 +162,8 @@ export default class DisplayComponent extends Component {
       <InspectorControls>
         <PanelBody title={/* translators: [admin] */ __('Display Options', 'amnesty')}>
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Background Colour', 'amnesty')}
             options={[
@@ -174,6 +176,8 @@ export default class DisplayComponent extends Component {
             onChange={(background) => setAttributes({ background })}
           />
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Choose taxonomy to display', 'amnesty')}
             options={options}

--- a/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
@@ -214,18 +214,24 @@ class DisplayComponent extends Component {
             allowReset
           />
           <ToggleControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Toggle Background Overlay', 'amnesty')}
             checked={attributes.enableBackgroundGradient}
             onChange={(enableBackgroundGradient) => setAttributes({ enableBackgroundGradient })}
           />
           <ToggleControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Hide Image Caption', 'amnesty')}
             checked={attributes.hideImageCaption}
             onChange={() => setAttributes({ hideImageCaption: !attributes.hideImageCaption })}
           />
           <ToggleControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Hide Image Credit', 'amnesty')}
             checked={attributes.hideImageCopyright}

--- a/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
@@ -4,8 +4,6 @@ const { apiFetch } = wp;
 const { InspectorControls, InnerBlocks, MediaUpload, MediaUploadCheck } = wp.blockEditor;
 const { Button, PanelBody, RangeControl, SelectControl, TextControl, ToggleControl } =
   wp.components;
-const { compose } = wp.compose;
-const { withDispatch } = wp.data;
 const { Component, Fragment } = wp.element;
 const { __, sprintf } = wp.i18n;
 
@@ -370,6 +368,4 @@ class DisplayComponent extends Component {
   }
 }
 
-export default compose(
-  withDispatch((dispatch) => dispatch('core/block-editor').setTemplateValidity(true)),
-)(DisplayComponent);
+export default DisplayComponent;

--- a/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
@@ -144,6 +144,8 @@ class DisplayComponent extends Component {
             onChange={this.handleSave}
           />
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Text Colour', 'amnesty')}
             options={[
@@ -228,6 +230,8 @@ class DisplayComponent extends Component {
             onChange={() => setAttributes({ hideImageCopyright: !attributes.hideImageCopyright })}
           />
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Background Image Origin', 'amnesty')}
             options={[
@@ -266,6 +270,8 @@ class DisplayComponent extends Component {
             onChange={(value) => setAttributes({ backgroundImageOrigin: value })}
           />
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Background Colour', 'amnesty')}
             options={[

--- a/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
@@ -198,6 +198,8 @@ class DisplayComponent extends Component {
             </MediaUploadCheck>
           </div>
           <RangeControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Min image height as viewport percentage', 'amnesty')}
             onChange={(value) => setAttributes({ minHeight: !value ? 0 : value })}

--- a/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/section/DisplayComponent.jsx
@@ -138,6 +138,8 @@ class DisplayComponent extends Component {
       <InspectorControls>
         <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
           <TextControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Section Name', 'amnesty')}
             value={attributes.sectionName}

--- a/private/src/scripts/editor/blocks/section/index.jsx
+++ b/private/src/scripts/editor/blocks/section/index.jsx
@@ -22,6 +22,7 @@ registerBlockType('amnesty-core/block-section', {
     },
     sectionName: {
       type: 'string',
+      default: '',
     },
     backgroundImage: {
       type: 'string',

--- a/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
@@ -218,6 +218,8 @@ class DisplayComponent extends Component {
       <InspectorControls>
         <PanelBody title={/* translators: [admin] */ __('Options', 'amnesty')}>
           <ToggleControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Show Arrows', 'amnesty')}
             checked={attributes.hasArrows}
@@ -225,6 +227,8 @@ class DisplayComponent extends Component {
           />
 
           <ToggleControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Has Content', 'amnesty')}
             checked={attributes.hasContent}
@@ -242,6 +246,8 @@ class DisplayComponent extends Component {
           />
 
           <ToggleControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Show Tabs', 'amnesty')}
             checked={attributes.showTabs}
@@ -328,6 +334,8 @@ class DisplayComponent extends Component {
               onChange={updateSlide('background')}
             />
             <ToggleControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Hide Content', 'amnesty')}
               checked={currentSlide.hideContent}

--- a/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
@@ -261,6 +261,8 @@ class DisplayComponent extends Component {
 
         <PanelBody title={/* translators: [admin] */ __('Timeline Options', 'amnesty')}>
           <TextControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Slider Title', 'amnesty')}
             onChange={this.createUpdateAttribute('sliderTitle')}
@@ -280,6 +282,8 @@ class DisplayComponent extends Component {
         {attributes.slides.length > 0 && (
           <PanelBody title={/* translators: [admin] */ __('Slide Options', 'amnesty')}>
             <TextControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Slide Title', 'amnesty')}
               onChange={updateSlide('title')}

--- a/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
@@ -286,6 +286,7 @@ class DisplayComponent extends Component {
               value={currentSlide.title}
             />
             <TextareaControl
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Slide Timeline Text', 'amnesty')}
               onChange={updateSlide('timelineContent')}

--- a/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
@@ -499,7 +499,7 @@ class DisplayComponent extends Component {
 
                   if (selectedSlide === index) {
                     return (
-                      <div key={slide.title} className="slider-navButton is-active">
+                      <div key={slide.id} className="slider-navButton is-active">
                         <span>
                           {slideTitle
                             ? slide.title
@@ -511,7 +511,7 @@ class DisplayComponent extends Component {
 
                   return (
                     <button
-                      key={slide.title}
+                      key={slide.id}
                       className="slider-navButton"
                       onClick={this.createSelectSlide(index)}
                     >

--- a/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/slider/DisplayComponent.jsx
@@ -267,6 +267,8 @@ class DisplayComponent extends Component {
             value={attributes.sliderTitle}
           />
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Timeline Style', 'amnesty')}
             value={attributes.timelineCaptionStyle}
@@ -303,6 +305,8 @@ class DisplayComponent extends Component {
             />
             <hr />
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Content Alignment', 'amnesty')}
               value={currentSlide.alignment}
@@ -310,6 +314,8 @@ class DisplayComponent extends Component {
               onChange={updateSlide('alignment')}
             />
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Background Style', 'amnesty')}
               value={currentSlide.background}

--- a/private/src/scripts/editor/blocks/stat-counter/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/stat-counter/DisplayComponent.jsx
@@ -15,7 +15,7 @@ const toRawNumber = (value = '0') => {
   const trimmed = value.replace(/[^\d]/g, '');
   const inted = parseInt(trimmed, 10);
 
-  return inted;
+  return Number.isNaN(inted) ? 0 : inted;
 };
 
 // format a value as a locale-aware number

--- a/private/src/scripts/editor/blocks/stat-counter/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/stat-counter/DisplayComponent.jsx
@@ -106,6 +106,8 @@ export default class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody>
             <RangeControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Duration', 'amnesty')}
               // translators: [admin]

--- a/private/src/scripts/editor/blocks/stat-counter/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/stat-counter/DisplayComponent.jsx
@@ -136,6 +136,8 @@ export default class DisplayComponent extends Component {
         <div className={blockClasses}>
           {!preview && (
             <TextControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Enter the value to which this field should count', 'amnesty')}
               value={toFormattedString(attributes.value)}

--- a/private/src/scripts/editor/blocks/term-list/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/term-list/DisplayComponent.jsx
@@ -73,7 +73,7 @@ export default class DisplayComponent extends Component {
 
     const path = addQueryArgs(`/wp/v2/${current.rest_base}/`, {
       hide_empty: 'false',
-      per_page: '250',
+      per_page: current.rest_base === 'category' ? 100 : 250,
     });
 
     if (cache[path]) {

--- a/private/src/scripts/editor/blocks/term-list/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/term-list/DisplayComponent.jsx
@@ -10,7 +10,7 @@ const groupTerms = (terms) => {
   const grouped = {};
 
   terms
-    .filter(({ hidden, type }) => type === 'default' && !hidden)
+    .filter(({ type }) => type === 'default')
     .forEach((term) => {
       const char = term.name.charAt(0).toUpperCase();
       if (!has(grouped, char)) {

--- a/private/src/scripts/editor/blocks/term-list/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/term-list/DisplayComponent.jsx
@@ -10,7 +10,7 @@ const groupTerms = (terms) => {
   const grouped = {};
 
   terms
-    .filter(({ type }) => type === 'default')
+    .filter(({ type }) => !type || type === 'default')
     .forEach((term) => {
       const char = term.name.charAt(0).toUpperCase();
       if (!has(grouped, char)) {

--- a/private/src/scripts/editor/blocks/term-list/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/term-list/DisplayComponent.jsx
@@ -111,6 +111,8 @@ export default class DisplayComponent extends Component {
       <InspectorControls>
         <PanelBody title={/* translators: [admin] */ __('Display Options', 'amnesty')}>
           <SelectControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Choose taxonomy to display', 'amnesty')}
             options={options}

--- a/private/src/scripts/editor/blocks/tweet/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/tweet/DisplayComponent.jsx
@@ -50,6 +50,8 @@ export default class DisplayComponent extends Component {
         <InspectorControls>
           <PanelBody>
             <SelectControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Size', 'amnesty')}
               value={size}

--- a/private/src/scripts/editor/blocks/tweet/DisplayComponent.jsx
+++ b/private/src/scripts/editor/blocks/tweet/DisplayComponent.jsx
@@ -64,6 +64,8 @@ export default class DisplayComponent extends Component {
               ]}
             />
             <ToggleControl
+              __next40pxDefaultSize
+              __nextHasNoMarginBottom
               // translators: [admin]
               label={__('Embed Link', 'amnesty')}
               // translators: [admin]

--- a/private/src/scripts/editor/components/MediaMetadataVisibilityControls.jsx
+++ b/private/src/scripts/editor/components/MediaMetadataVisibilityControls.jsx
@@ -17,11 +17,15 @@ const MediaMetadataVisibilityControls = ({ type, hideCaption, hideCopyright, set
   return (
     <>
       <ToggleControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         label={captionLabel}
         checked={hideCaption}
         onChange={() => setAttributes({ hideImageCaption: !hideCaption })}
       />
       <ToggleControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         label={copyrightLabel}
         checked={hideCopyright}
         onChange={() => setAttributes({ hideImageCopyright: !hideCopyright })}

--- a/private/src/scripts/editor/components/PostFeaturedVideo.jsx
+++ b/private/src/scripts/editor/components/PostFeaturedVideo.jsx
@@ -76,7 +76,7 @@ class PostFeaturedVideo extends Component {
                 <video>
                   <source src={media.source_url || media.url} />
                 </video>
-                <Button onClick={open} isSecondary isLarge>
+                <Button onClick={open} isSecondary>
                   {/* translators: [admin] */ __('Replace Video', 'amnesty')}
                 </Button>
               </div>

--- a/private/src/scripts/editor/components/PostMediaSelector.jsx
+++ b/private/src/scripts/editor/components/PostMediaSelector.jsx
@@ -112,7 +112,7 @@ class PostMediaSelector extends Component {
                 {!loading && mediaType === 'image' && <img src={media.source_url || media.url} />}
 
                 {loading && <Spinner />}
-                <Button onClick={open} isSecondary isLarge>
+                <Button onClick={open} isSecondary>
                   {replaceMediaLabel}
                 </Button>
               </div>

--- a/private/src/scripts/editor/plugins/appearance-options/components/Byline.jsx
+++ b/private/src/scripts/editor/plugins/appearance-options/components/Byline.jsx
@@ -70,6 +70,8 @@ const Byline = () => {
     <>
       <PanelRow>
         <ToggleControl
+          __next40pxDefaultSize
+          __nextHasNoMarginBottom
           // translators: [admin]
           label={__('Enable public byline', 'amnesty')}
           help={
@@ -86,6 +88,8 @@ const Byline = () => {
       {bylineEnabled && (
         <PanelRow>
           <ToggleControl
+            __next40pxDefaultSize
+            __nextHasNoMarginBottom
             // translators: [admin]
             label={__('Use author profile for byline', 'amnesty')}
             checked={bylineIsAuthor}

--- a/private/src/scripts/editor/plugins/appearance-options/components/FeaturedImage.jsx
+++ b/private/src/scripts/editor/plugins/appearance-options/components/FeaturedImage.jsx
@@ -13,6 +13,8 @@ const { __ } = wp.i18n;
 const FeaturedImage = ({ createMetaUpdate, props }) => (
   <>
     <ToggleControl
+      __next40pxDefaultSize
+      __nextHasNoMarginBottom
       label={__('Hide featured image', 'amnesty')}
       help={__('Hide the featured image.', 'amnesty')}
       checked={props.meta._hide_featured_image}
@@ -26,6 +28,8 @@ const FeaturedImage = ({ createMetaUpdate, props }) => (
       }
     />
     <ToggleControl
+      __next40pxDefaultSize
+      __nextHasNoMarginBottom
       label={__('Hide featured image caption', 'amnesty')}
       help={__('Hide the image caption for the featured image', 'amnesty')}
       checked={props.meta._hide_featured_image_caption}

--- a/private/src/scripts/editor/plugins/appearance-options/components/Header.jsx
+++ b/private/src/scripts/editor/plugins/appearance-options/components/Header.jsx
@@ -21,6 +21,8 @@ const Header = ({ createMetaUpdate, props }) => {
   return (
     <PanelBody title={/* translators: [admin] */ __('Header', 'amnesty')}>
       <ToggleControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         label={__('Use transparent header', 'amnesty')}
         help={__(
           'Enable transparent mode on the main header. Requires the use of a header block with a featured image',

--- a/private/src/scripts/editor/plugins/appearance-options/components/Metadata.jsx
+++ b/private/src/scripts/editor/plugins/appearance-options/components/Metadata.jsx
@@ -60,6 +60,8 @@ function IndexNumber() {
 const PublishedDate = ({ createMetaUpdate, props }) => (
   <>
     <ToggleControl
+      __next40pxDefaultSize
+      __nextHasNoMarginBottom
       label={/* translators: [admin] */ __('Show published date', 'amnesty')}
       help={/* translators: [admin] */ __('Show the post published date', 'amnesty')}
       checked={props.meta.show_published_date}
@@ -87,6 +89,8 @@ const PublishedDate = ({ createMetaUpdate, props }) => (
 const UpdatedDate = ({ createMetaUpdate, props }) => (
   <>
     <ToggleControl
+      __next40pxDefaultSize
+      __nextHasNoMarginBottom
       label={/* translators: [admin] */ __('Show updated date', 'amnesty')}
       help={/* translators: [admin] */ __('Show the "updated at" date', 'amnesty')}
       checked={props.meta.show_updated_date}

--- a/private/src/scripts/editor/plugins/appearance-options/components/RelatedContent.jsx
+++ b/private/src/scripts/editor/plugins/appearance-options/components/RelatedContent.jsx
@@ -11,6 +11,8 @@ const { __ } = wp.i18n;
  */
 const RelatedContent = ({ createMetaUpdate, props }) => (
   <ToggleControl
+    __next40pxDefaultSize
+    __nextHasNoMarginBottom
     // translators: [admin]
     label={__('Disable Related Content', 'amnesty')}
     // translators: [admin]

--- a/private/src/scripts/editor/plugins/appearance-options/components/ShareButtons.jsx
+++ b/private/src/scripts/editor/plugins/appearance-options/components/ShareButtons.jsx
@@ -14,6 +14,8 @@ const { __ } = wp.i18n;
 const ShareButtons = ({ createMetaUpdate, props }) => (
   <>
     <ToggleControl
+      __next40pxDefaultSize
+      __nextHasNoMarginBottom
       // translators: [admin]
       label={__('Disable Sharing', 'amnesty')}
       // translators: [admin]

--- a/private/src/scripts/editor/plugins/appearance-options/components/Sidebar.jsx
+++ b/private/src/scripts/editor/plugins/appearance-options/components/Sidebar.jsx
@@ -19,6 +19,8 @@ const Sidebar = ({ createMetaUpdate, props }) => {
   return (
     <PanelBody title={/* translators: [admin] */ __('Sidebar', 'amnesty')} initialOpen={false}>
       <ToggleControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         // translators: [admin]
         label={__('Maximize Content', 'amnesty')}
         help={
@@ -39,6 +41,8 @@ const Sidebar = ({ createMetaUpdate, props }) => {
         }
       />
       <ToggleControl
+        __next40pxDefaultSize
+        __nextHasNoMarginBottom
         // translators: [admin]
         label={__('Disable Sidebar', 'amnesty')}
         help={

--- a/private/src/scripts/editor/plugins/appearance-options/components/TermFeature.jsx
+++ b/private/src/scripts/editor/plugins/appearance-options/components/TermFeature.jsx
@@ -44,6 +44,8 @@ const TermFeature = ({ createMetaUpdate, props }) => {
 
   return (
     <SelectControl
+      __next40pxDefaultSize
+      __nextHasNoMarginBottom
       // translators: [admin]
       label={__('Feature on content type:', 'amnesty')}
       value={props.meta.term_slider}

--- a/private/src/scripts/editor/plugins/pop-in/index.jsx
+++ b/private/src/scripts/editor/plugins/pop-in/index.jsx
@@ -46,6 +46,8 @@ const PopInSettings = (props) => {
         title={/* translators: [admin] */ __('Pop-in Settings', 'amnesty')}
       >
         <ToggleControl
+          __next40pxDefaultSize
+          __nextHasNoMarginBottom
           // translators: [admin]
           label={__('Render Title', 'amnesty')}
           // translators: [admin]

--- a/private/src/scripts/modules/counter.js
+++ b/private/src/scripts/modules/counter.js
@@ -60,6 +60,12 @@ const countUp = (target, end, duration = 2000, observerObj) => {
   requestAnimationFrame(step);
 };
 
+// Ensure bottom margin is never less than footer height so it triggers even with an empty footer.
+const bottomMargin = Math.min(
+  document.querySelector('.wp-site-blocks > footer, body > footer')?.offsetHeight ?? 0,
+  200,
+);
+
 // animate once the element's well into view
 const observer = new IntersectionObserver(
   (entries, observerObj) => {
@@ -79,7 +85,7 @@ const observer = new IntersectionObserver(
     });
   },
   {
-    rootMargin: '0px 0px -200px 0px',
+    rootMargin: `0px 0px -${bottomMargin}px 0px`,
     threshold: [1],
   },
 );

--- a/private/src/scripts/modules/counter.js
+++ b/private/src/scripts/modules/counter.js
@@ -10,7 +10,7 @@ const toRawNumber = (value = '0') => {
   const trimmed = value.replace(/[^\d]/g, '');
   const inted = parseInt(trimmed, 10);
 
-  return inted;
+  return Number.isNaN(inted) ? 0 : inted;
 };
 
 // format a value as a locale-aware number

--- a/private/src/scripts/modules/navigation.js
+++ b/private/src/scripts/modules/navigation.js
@@ -6,6 +6,10 @@ let subMenus = [];
 // if menu has lost focus inadvertently, restore it
 const setupFocusTrap = () => {
   const lastMenuItem = pageHeader.querySelector('.mobile-menu > ul > li:last-of-type');
+  if (!lastMenuItem) {
+    // Bail out if empty menu.
+    return;
+  }
   const menuItemClassList = `.${Array.from(lastMenuItem.classList).join('.')}`;
   let previousFocus;
 

--- a/private/src/styles/editor.scss
+++ b/private/src/styles/editor.scss
@@ -90,6 +90,12 @@
 @import "pages/search";
 @import "pages/single";
 
+// Workarounds
+// https://github.com/WordPress/gutenberg/issues/49796
+.block-editor-block-inspector .components-datetime .components-base-control {
+  margin-bottom: 0;
+}
+
 html {
   box-sizing: border-box;
 }

--- a/wp-content/themes/humanity-theme/includes/blocks/custom-card/register.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/custom-card/register.php
@@ -44,13 +44,14 @@ if ( ! function_exists( 'register_custom_card_block' ) ) {
 						'type' => 'string',
 					],
 					'scrollLink'    => [
-						'type' => 'string',
+						'type'    => 'string',
+						'default' => '',
 					],
 					'style'         => [
 						'type' => 'string',
 					],
 				],
-			] 
+			]
 		);
 	}
 }

--- a/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
@@ -25,8 +25,8 @@ if ( ! function_exists( 'render_stat_counter_block' ) ) {
 		);
 
 		$alignment = 'align' . $attributes['alignment'];
-		$duration  = intval( $attributes['duration'] );
-		$value     = intval( $attributes['value'] );
+		$duration  = intval( $attributes['duration'], 10 );
+		$value     = intval( $attributes['value'], 10 );
 
 		if ( 'on' === ( $options['enforce_grouping_separators'] ?? false ) ) {
 			$value = number_format_i18n( $value );

--- a/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/stat-counter/render.php
@@ -25,8 +25,8 @@ if ( ! function_exists( 'render_stat_counter_block' ) ) {
 		);
 
 		$alignment = 'align' . $attributes['alignment'];
-		$duration  = $attributes['duration'];
-		$value     = $attributes['value'];
+		$duration  = intval( $attributes['duration'] );
+		$value     = intval( $attributes['value'] );
 
 		if ( 'on' === ( $options['enforce_grouping_separators'] ?? false ) ) {
 			$value = number_format_i18n( $value );

--- a/wp-content/themes/humanity-theme/includes/blocks/term-list/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/term-list/render.php
@@ -82,7 +82,7 @@ if ( ! function_exists( 'amnesty_render_term_list_block' ) ) {
 		}
 
 		$letters = array_keys( $groups );
-		$first   = $letters[0]; // used in view
+		$first   = empty( $letters ) ? '' : $letters[0]; // used in view
 
 		spaceless();
 		require realpath( __DIR__ . '/views/term-list.php' );

--- a/wp-content/themes/humanity-theme/includes/blocks/tweet-action/render.php
+++ b/wp-content/themes/humanity-theme/includes/blocks/tweet-action/render.php
@@ -17,6 +17,7 @@ if ( ! function_exists( 'amnesty_render_tweet_action' ) ) {
 			$attributes,
 			[
 				'className' => '',
+				'content'   => '',
 				'size'      => '',
 				'alignment' => 'center',
 			] 

--- a/wp-content/themes/humanity-theme/includes/full-site-editing/blocks/search-header/render.php
+++ b/wp-content/themes/humanity-theme/includes/full-site-editing/blocks/search-header/render.php
@@ -13,6 +13,10 @@ if ( ! function_exists( 'render_search_header_block' ) ) {
 	 * @return string
 	 */
 	function render_search_header_block( array $attributes, string $content, WP_Block $block ): string {
+		if ( ! isset( $block->context['query'] ) ) {
+			return '';
+		}
+
 		/**
 		 * The core/query block neither instantiates nor executes
 		 * the query declared in it. For some reason, that's done
@@ -33,7 +37,7 @@ if ( ! function_exists( 'render_search_header_block' ) ) {
 		 *
 		 * - @jaymcp
 		 */
-		$query = build_query_vars_from_query_block( $block->context['query'], get_query_var( 'paged', 1 ) );
+		$query = build_query_vars_from_query_block( $block, get_query_var( 'paged', 1 ) );
 		$query = new WP_Query( $query );
 
 		spaceless();


### PR DESCRIPTION
Ref: #500 

**Steps to test**:
1. Check [sizes](https://make.wordpress.org/core/2023/10/16/editor-components-updates-in-wordpress-6-4/#improving-size-consistency-for-ui-components) and [spacings](https://make.wordpress.org/core/2024/10/18/editor-components-updates-in-wordpress-6-7/#bottom-margin-styles-are-deprecated) of UI components still look as intended.
2. There are (almost) no browser console warnings in the block editor any more. There is a helper script that can help during testing to [tone down the browser console noise](https://github.com/amnestywebsite/humanity-theme/issues/500#issuecomment-5342798262).

**Considerations**:
- Accessibility
  - Regions (semantic HTML tags, e.g. `<section>`; [landmarks](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#landmark_roles); etc.)
  - Screen reader compatibility, labels ([`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label), [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby), etc.)
  - Keyboard navigability
- Localisation
- RTL
